### PR TITLE
fix typo of not prepared exception.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFireStoreDatabase.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFireStoreDatabase.kt
@@ -44,7 +44,7 @@ class FavoriteFireStoreDatabase : FavoriteDatabase {
     })
 
     override fun favorite(session: Session): Single<Boolean> = if (!isInitialized) {
-        Single.error(NotPrepairedException())
+        Single.error(NotPreparedException())
     } else {
         getCurrentUser().flatMap { currentUser ->
             return@flatMap Single.create<Boolean>({ e ->
@@ -164,7 +164,7 @@ class FavoriteFireStoreDatabase : FavoriteDatabase {
         })
     }
 
-    class NotPrepairedException : RuntimeException()
+    class NotPreparedException : RuntimeException()
 
     companion object {
         private const val DEBUG: Boolean = false


### PR DESCRIPTION
## Issue
- #73 

## Overview (Required)
- fix typo of exception name. (NotPrepairedException to NotPreparedException)