### PR TITLE
Change session header item text order depend on language

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/SessionHeaderItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/SessionHeaderItem.kt
@@ -5,6 +5,7 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ItemSearchSessionHeaderBinding
 import io.github.droidkaigi.confsched2018.model.Lang
 import io.github.droidkaigi.confsched2018.model.Level
+import io.github.droidkaigi.confsched2018.util.lang
 
 data class SessionHeaderItem(
         val level: Level
@@ -12,8 +13,13 @@ data class SessionHeaderItem(
         level.id.toLong()
 ) {
     override fun bind(viewBinding: ItemSearchSessionHeaderBinding, position: Int) {
-        viewBinding.title.text = level.getNameByLang(Lang.JA)
-        viewBinding.subTitle.text = level.getNameByLang(Lang.EN)
+        if (lang() == Lang.JA) {
+            viewBinding.title.text = level.getNameByLang(Lang.JA)
+            viewBinding.subTitle.text = level.getNameByLang(Lang.EN)
+        } else {
+            viewBinding.title.text = level.getNameByLang(Lang.EN)
+            viewBinding.subTitle.text = level.getNameByLang(Lang.JA)
+        }
     }
 
     override fun getLayout(): Int = R.layout.item_search_session_header


### PR DESCRIPTION
## Issue
- #69 

## Overview (Required)
- Change session header item text order depend on language setting

## Screenshot
Case JP | Case EN
:--: | :--:
<img src="https://user-images.githubusercontent.com/22738004/34903203-f8971752-f86f-11e7-8aac-bef342c7d5d4.png" width="300" /> | <img src="https://user-images.githubusercontent.com/22738004/34903206-01fa3a90-f870-11e7-8103-add6d37f9dae.png" width="300" />