### PR TITLE
Remove needless "/" from the lunch session

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -21,13 +21,8 @@ fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
 @BindingAdapter(value = ["bind:prefix", "bind:roomName"])
 fun TextView.setRoomText(prefix: String?, roomName: String?) {
     prefix ?: return
-    text = when (roomName) {
-        null -> ""
-        else -> context.getString(
-                R.string.room_format,
-                prefix,
-                roomName
-        )
+    text = when (roomName) { null -> ""
+        else -> context.getString(R.string.room_format, prefix, roomName)
     }
 }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -21,7 +21,7 @@ fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
 @BindingAdapter(value = ["bind:prefix", "bind:roomName"])
 fun TextView.setRoomText(prefix: String?, roomName: String?) {
     prefix ?: return
-    text = when(roomName) {
+    text = when (roomName) {
         null -> ""
         else -> context.getString(
                 R.string.room_format,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -7,21 +7,28 @@ import io.github.droidkaigi.confsched2018.model.Date
 import io.github.droidkaigi.confsched2018.model.toReadableDateTimeString
 import io.github.droidkaigi.confsched2018.model.toReadableTimeString
 
-@BindingAdapter(value = ["bind:startDate", "bind:endDate", "bind:postFix"])
-fun TextView.setPeriodText(startDate: Date?, endDate: Date?, postFix: String) {
+@BindingAdapter(value = ["bind:startDate", "bind:endDate"])
+fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
     startDate ?: return
     endDate ?: return
     text = context.getString(
             R.string.time_period,
             startDate.toReadableTimeString(),
-            endDate.toReadableTimeString(),
-            postFix
+            endDate.toReadableTimeString()
     )
 }
 
-@BindingAdapter(value = ["bind:startDate", "bind:endDate"])
-fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
-    setPeriodText(startDate, endDate, "")
+@BindingAdapter(value = ["bind:prefix", "bind:roomName"])
+fun TextView.setRoomText(prefix: String?, roomName: String?) {
+    prefix ?: return
+    text = when(roomName) {
+        null -> ""
+        else -> context.getString(
+                R.string.room_format,
+                prefix,
+                roomName
+        )
+    }
 }
 
 @BindingAdapter(value = ["android:text"])

--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -54,13 +54,13 @@
                 android:id="@+id/room"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
                 android:maxLines="3"
-                android:text="@{session.room.name}"
                 android:textAppearance="@style/TextAppearance.App.Caption"
                 app:layout_constraintStart_toEndOf="@id/period"
                 app:layout_constraintTop_toTopOf="@+id/period"
-                tools:text="Room A"
+                app:prefix='@{" / "}'
+                app:roomName="@{session.room.name}"
+                tools:text=" / Room A"
                 />
 
             <TextView

--- a/app/src/main/res/layout/item_special_session.xml
+++ b/app/src/main/res/layout/item_special_session.xml
@@ -63,7 +63,6 @@
                 app:layout_constraintTop_toTopOf="@id/day_number"
                 app:layout_goneMarginStart="12dp"
                 app:layout_goneMarginTop="16dp"
-                app:postFix='@{" / "}'
                 app:startDate="@{session.startTime}"
                 tools:text="10:30 - 11:00 / "
                 />
@@ -73,10 +72,11 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:maxLines="3"
-                android:text="@{session.room.name}"
                 android:textAppearance="@style/TextAppearance.App.Caption"
                 app:layout_constraintStart_toEndOf="@id/period"
                 app:layout_constraintTop_toTopOf="@+id/period"
+                app:prefix='@{" / "}'
+                app:roomName="@{session.room.name}"
                 tools:text="Room A"
                 />
 

--- a/app/src/main/res/layout/item_speech_session.xml
+++ b/app/src/main/res/layout/item_speech_session.xml
@@ -63,9 +63,8 @@
                 app:layout_constraintTop_toTopOf="@id/day_number"
                 app:layout_goneMarginStart="12dp"
                 app:layout_goneMarginTop="16dp"
-                app:postFix='@{" / "}'
                 app:startDate="@{session.startTime}"
-                tools:text="10:30 - 11:00 / "
+                tools:text="10:30 - 11:00"
                 />
 
             <TextView
@@ -73,11 +72,12 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:maxLines="3"
-                android:text="@{session.room.name}"
                 android:textAppearance="@style/TextAppearance.App.Caption"
                 app:layout_constraintStart_toEndOf="@id/period"
                 app:layout_constraintTop_toTopOf="@+id/period"
-                tools:text="Room A"
+                app:prefix='@{" / "}'
+                app:roomName="@{session.room.name}"
+                tools:text=" / Room A"
                 />
 
             <TextView

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Common -->
-    <string name="time_period">%1$s - %2$s%3$s</string>
+    <string name="time_period">%1$s - %2$s</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_map">アクセス</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Common -->
-    <string name="time_period">%1$s - %2$s%3$s</string>
+    <string name="time_period">%1$s - %2$s</string>
+    <string name="room_format">%1$s%2$s</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_map">Map</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <!-- Common -->
     <string name="time_period">%1$s - %2$s</string>
-    <string name="room_format">%1$s%2$s</string>
+    <string name="room_format" translatable="false">%1$s%2$s</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_map">Map</string>


### PR DESCRIPTION
## Issue
- close #58

## Overview (Required)
- Removed needless "/" from the lunch session.
  - Used the format `hh:ss - hh:ss` ` / @{roomName}` instead of `hh:ss - hh:ss  / ` `@{roomName}`.
- Added (probably had been forgotten to put) "/" for the item_horizontal_session's roomName.
  - Please see the second screenshot.
  - If this format was intended, I'll revert 🙇 

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8403570/34903805-87844bea-f87c-11e7-84de-271c31211be2.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8403570/34903806-88dda5c2-f87c-11e7-8067-b8d679c601ec.png" width="300" />
<img src="https://user-images.githubusercontent.com/8403570/34903794-7086aec4-f87c-11e7-9636-fd006cbbf059.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8403570/34903798-75f34caa-f87c-11e7-99ef-735ba5129494.png" width="300" />
