### PR TITLE
Disable drawer slide animation

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -20,18 +20,19 @@ class DrawerMenu @Inject constructor(
             actionBarDrawerSync: Boolean = false
     ) {
         if (actionBarDrawerSync) {
-            val actionBarDrawerToggle = ActionBarDrawerToggle(
+            ActionBarDrawerToggle(
                     activity,
                     drawerLayout,
                     toolbar,
                     R.string.nav_content_description_drawer_open,
                     R.string.nav_content_description_drawer_close
-            )
-            actionBarDrawerToggle.isDrawerIndicatorEnabled = true
-            actionBarDrawerToggle.isDrawerSlideAnimationEnabled = true
-            drawerLayout.addDrawerListener(
-                    actionBarDrawerToggle)
-            actionBarDrawerToggle.syncState()
+            ).also {
+                drawerLayout.addDrawerListener(it)
+            }.apply {
+                isDrawerIndicatorEnabled = true
+                isDrawerSlideAnimationEnabled = true
+                syncState()
+            }
         }
         navigationView.setNavigationItemSelectedListener { item ->
             when (item.itemId) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -28,6 +28,7 @@ class DrawerMenu @Inject constructor(
                     R.string.nav_content_description_drawer_close
             )
             actionBarDrawerToggle.isDrawerIndicatorEnabled = true
+            actionBarDrawerToggle.isDrawerSlideAnimationEnabled = true
             drawerLayout.addDrawerListener(
                     actionBarDrawerToggle)
             actionBarDrawerToggle.syncState()


### PR DESCRIPTION
## Overview
- Disable the drawer slide animation as the drawer actually covers it.
- Refactored some kotlin code for fun.

## Links
- [setDrawerSlideAnimationEnabled(boolean)](https://developer.android.com/reference/android/support/v7/app/ActionBarDrawerToggle.html#setDrawerSlideAnimationEnabled(boolean))

## Screenshot
Before | After
:--: | :--:
![disable-drawer-slide-before](https://user-images.githubusercontent.com/1767669/34903955-30e80850-f87f-11e7-8186-962715b89c04.gif) | ![disable-drawer-slide-after](https://user-images.githubusercontent.com/1767669/34903954-30c3d066-f87f-11e7-97e1-f15b7e602476.gif)
