### PR TITLE
ReadableXXFormat is not thread safe.

### DIFF
--- a/common-jvm/src/main/kotlin/JvmDate.kt
+++ b/common-jvm/src/main/kotlin/JvmDate.kt
@@ -42,8 +42,8 @@ actual class Date {
 
 actual operator fun Date.compareTo(otherDate: Date): Int = date.compareTo(otherDate.date)
 
-val readableDateFormat = SimpleDateFormat("MM/dd", Locale.getDefault())
-val readableTimeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
-actual fun Date.toReadableDateString() = readableDateFormat.format(date)
-actual fun Date.toReadableTimeString() = readableTimeFormat.format(date)
+fun readableDateFormat() = SimpleDateFormat("MM/dd", Locale.getDefault())
+fun readableTimeFormat() = SimpleDateFormat("HH:mm", Locale.getDefault())
+actual fun Date.toReadableDateString() = readableDateFormat().format(date)
+actual fun Date.toReadableTimeString() = readableTimeFormat().format(date)
 actual fun parseDate(timeInMills: Long): Date = Date(timeInMills)


### PR DESCRIPTION
`Date.toReadableDateString` and `Date.toReadableTimeString` are not thread safe.

## Issue

* N/A

## Overview (Required)

Fix thread problem in common-jvm project.

Sharing `java.text.SimpleDateFormat` will cause a failure in printing dates.

## Links

* N/A
## Screenshot

* N/A
