### PR TITLE
disable shift mode for BottomNavigationView

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -12,6 +12,7 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ActivityMainBinding
 import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActivity
 import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
+import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLolipop
 import javax.inject.Inject
 
@@ -34,7 +35,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     }
 
     private fun setupBottomNavigation(savedInstanceState: Bundle?) {
-
+        binding.bottomNavigation.disableShiftMode()
         binding.bottomNavigation.itemIconTintList = null
         binding.bottomNavigation.setOnNavigationItemSelectedListener({ item ->
             val navigationItem = BottomNavigationItem

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/BottomNavigationViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/BottomNavigationViewExt.kt
@@ -1,0 +1,30 @@
+package io.github.droidkaigi.confsched2018.util.ext
+
+import android.annotation.SuppressLint
+import android.support.design.internal.BottomNavigationItemView
+import android.support.design.internal.BottomNavigationMenuView
+import android.support.design.widget.BottomNavigationView
+import android.util.Log
+
+@SuppressLint("RestrictedApi")
+fun BottomNavigationView.disableShiftMode() {
+    val menuView = this.getChildAt(0) as BottomNavigationMenuView
+    try {
+        val shiftingMode = menuView.javaClass.getDeclaredField("mShiftingMode")
+        shiftingMode.isAccessible = true
+        shiftingMode.setBoolean(menuView, false)
+        shiftingMode.isAccessible = false
+        for (i in 0 until menuView.childCount) {
+            val item = menuView.getChildAt(i) as BottomNavigationItemView
+
+            item.setShiftingMode(false)
+            // set once again checked value, so view will be updated
+
+            item.setChecked(item.itemData!!.isChecked)
+        }
+    } catch (e: NoSuchFieldException) {
+        Log.e("BNVHelper", "Unable to get shift mode field", e)
+    } catch (e: IllegalAccessException) {
+        Log.e("BNVHelper", "Unable to change value of shift mode", e)
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/BottomNavigationViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/BottomNavigationViewExt.kt
@@ -4,7 +4,10 @@ import android.annotation.SuppressLint
 import android.support.design.internal.BottomNavigationItemView
 import android.support.design.internal.BottomNavigationMenuView
 import android.support.design.widget.BottomNavigationView
-import android.util.Log
+import android.view.Gravity
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import timber.log.Timber
 
 @SuppressLint("RestrictedApi")
 fun BottomNavigationView.disableShiftMode() {
@@ -14,8 +17,23 @@ fun BottomNavigationView.disableShiftMode() {
         shiftingMode.isAccessible = true
         shiftingMode.setBoolean(menuView, false)
         shiftingMode.isAccessible = false
-        for (i in 0 until menuView.childCount) {
-            val item = menuView.getChildAt(i) as BottomNavigationItemView
+        menuView.eachChildView {
+            val item = it as BottomNavigationItemView
+            // NOTE: This removing the BottomNavigationItem labels including small and large text container.
+            item.removeViewAt(1)
+
+            // set the gravity of item icon to Center.
+            val lp = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT)
+            lp.gravity = Gravity.CENTER
+            item.getChildAt(0).layoutParams = lp
+
+            // remove the default top margin.
+            val topMargin = item.javaClass.getDeclaredField("mDefaultMargin")
+            topMargin.isAccessible = true
+            topMargin.setInt(item, 0)
+            topMargin.isAccessible = false
 
             item.setShiftingMode(false)
             // set once again checked value, so view will be updated
@@ -23,8 +41,8 @@ fun BottomNavigationView.disableShiftMode() {
             item.setChecked(item.itemData!!.isChecked)
         }
     } catch (e: NoSuchFieldException) {
-        Log.e("BNVHelper", "Unable to get shift mode field", e)
+        Timber.e(e, "Unable to get shift mode field")
     } catch (e: IllegalAccessException) {
-        Log.e("BNVHelper", "Unable to change value of shift mode", e)
+        Timber.e(e, "Unable to change value of shift mode")
     }
 }


### PR DESCRIPTION
Current BottomNavigationView has shift mode,
but it looks like a bit off.

## Issue
- close #Nothing

## Overview (Required)
- This is proposal for fixing the shift mode for BottomNavigationView.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6552589/34904621-3c600e34-f7fe-11e7-8e00-f5d1abc5973a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/6552589/34904620-36016b32-f7fe-11e7-81d9-80cd4132ffb7.png" width="300" /> 