### PR TITLE
Add ripple effect on the user search row

### DIFF
--- a/app/src/main/res/layout/item_speaker.xml
+++ b/app/src/main/res/layout/item_speaker.xml
@@ -12,7 +12,7 @@
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:foreground="?selectableItemBackground"
+        android:background="?selectableItemBackground"
         >
 
         <ImageView


### PR DESCRIPTION
## Issue

- close #102

## Overview (Required)

`android:foreground` can not be used in ConstraintLayout. Please refer to the following link.

## Links

- https://issuetracker.google.com/issues/37131310
- https://qiita.com/kuwapp/items/598ce3eeea60cb79d9e4

## Screenshot
Before | After
:--: | :--:
![102_before](https://user-images.githubusercontent.com/6926816/34905770-185ab05c-f8a3-11e7-8b36-b3868efa0933.gif) | ![102_after](https://user-images.githubusercontent.com/6926816/34905768-00e9f23e-f8a3-11e7-8538-beeebae3c58b.gif)





