### PR TITLE
Fix session card title cut off

### DIFF
--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -90,6 +90,7 @@
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="10dp"
                 android:lines="2"
+                android:lineSpacingExtra="@dimen/session_title_line_spacing"
                 android:text="@{session.title}"
                 android:textAppearance="@style/TextAppearance.App.Title"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Session -->
     <dimen name="speaker_image">28dp</dimen>
+    <dimen name="session_title_line_spacing">4sp</dimen>
 
     <!-- Feed -->
     <dimen name="feed_expand_button_size">48dp</dimen>


### PR DESCRIPTION
## Issue
- close #103

## Overview (Required)
- Add lineSpacingExtra in session card title

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/10655747/34905810-c5c76924-f8a3-11e7-9b24-19fdff99e9f0.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10655747/34905814-da04079e-f8a3-11e7-98a6-6587da5a5b3d.png" width="300" />
