### PR TITLE
Add paddingBottom to Next label in Session detail

### DIFF
--- a/app/src/main/res/layout/activity_session_detail.xml
+++ b/app/src/main/res/layout/activity_session_detail.xml
@@ -90,6 +90,7 @@
                 android:id="@+id/detail_sessions_next_label"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:paddingBottom="4dp"
                 android:text="@string/detail_sessions_next"
                 android:textAppearance="@style/TextAppearance.App.Caption"
                 android:textColor="@color/app_bar_text_color"


### PR DESCRIPTION
## Issue
- close #98

## Overview (Required)
- Add paddingBottom(4dp) attribute to "Next" label in Session detail bottom bar

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5158413/34906153-814f84e6-f8aa-11e7-9b6f-c3b805b2e617.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5158413/34906160-95b6b5f8-f8aa-11e7-86bf-9da701bb9c8d.png" width="300" />
