### PR TITLE
Optimize Dagger modules

### DIFF
--- a/app/src/debug/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/debug/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -17,16 +17,16 @@ import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
-@Module internal class NetworkModule {
+@Module internal object NetworkModule {
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
             .addNetworkInterceptor(HttpLoggingInterceptor()
                     .setLevel(HttpLoggingInterceptor.Level.BODY))
             .addNetworkInterceptor(StethoInterceptor())
             .build()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
                 .client(okHttpClient)
@@ -39,11 +39,11 @@ import javax.inject.Singleton
                 .build()
     }
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideDroidKaigiApi(retrofit: Retrofit): DroidKaigiApi {
         return retrofit.create(DroidKaigiApi::class.java)
     }
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideFeedApi(): FeedApi = FeedFireStoreApi()
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppModule.kt
@@ -15,9 +15,9 @@ import io.github.droidkaigi.confsched2018.util.rx.SchedulerProvider
 import javax.inject.Singleton
 
 @Module(includes = [(ViewModelModule::class)])
-internal class AppModule {
+internal object AppModule {
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSessionRepository(
             api: DroidKaigiApi,
             sessionDatabase: SessionDatabase,
@@ -26,12 +26,12 @@ internal class AppModule {
     ): SessionRepository =
             SessionDataRepository(api, sessionDatabase, favoriteDatabase, schedulerProvider)
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideFeedRepository(
             feedApi: FeedApi
     ): FeedRepository =
             FeedDataRepository(feedApi)
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSchedulerProvider(): SchedulerProvider = AppSchedulerProvider()
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/DatabaseModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/DatabaseModule.kt
@@ -14,9 +14,9 @@ import io.github.droidkaigi.confsched2018.data.db.dao.SessionSpeakerJoinDao
 import io.github.droidkaigi.confsched2018.data.db.dao.SpeakerDao
 import javax.inject.Singleton
 
-@Module internal class DatabaseModule {
+@Module internal object DatabaseModule {
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSessionDatabase(
             appDatabase: AppDatabase,
             sessionDbDao: SessionDao,
@@ -25,23 +25,23 @@ import javax.inject.Singleton
     ): SessionDatabase =
             SessionRoomDatabase(appDatabase, sessionDbDao, speakerDao, sessionSpeakerJoinDao)
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideFavoriteDatabase(): FavoriteDatabase =
             FavoriteFireStoreDatabase()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideDb(app: Application): AppDatabase =
             Room.databaseBuilder(app, AppDatabase::class.java, "droidkaigi.db")
                     .fallbackToDestructiveMigration()
                     .build()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSessionsDao(db: AppDatabase): SessionDao = db.sessionDao()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSpeakerDao(db: AppDatabase): SpeakerDao = db.speakerDao()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideSessionSpeakerJoinDao(db: AppDatabase): SessionSpeakerJoinDao =
             db.sessionSpeakerDao()
 }

--- a/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -16,15 +16,15 @@ import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
-@Module internal class NetworkModule {
+@Module internal object NetworkModule {
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
             .addNetworkInterceptor(HttpLoggingInterceptor()
                     .setLevel(HttpLoggingInterceptor.Level.BASIC))
             .build()
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
                 .client(okHttpClient)
@@ -37,11 +37,11 @@ import javax.inject.Singleton
                 .build()
     }
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideDroidKaigiApi(retrofit: Retrofit): DroidKaigiApi {
         return retrofit.create(DroidKaigiApi::class.java)
     }
 
-    @Singleton @Provides
+    @Singleton @Provides @JvmStatic
     fun provideFeedApi(): FeedApi = FeedFireStoreApi()
 }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Optimize Dagger modules

## Links
- https://medium.com/square-corner-blog/keeping-the-daggers-sharp-%EF%B8%8F-230b3191c3f

According to above article, `@Provides` methods can be static.
Then generated code do not need to make module instance and `@Provides` methods are invoked directly.
For example, following code is a generated one that provides the instance of OkHttpClient in NetworkModule.

### Before

```
public final class NetworkModule_ProvideOkHttpClientFactory implements Factory<OkHttpClient> {
  private final NetworkModule module;

  public NetworkModule_ProvideOkHttpClientFactory(NetworkModule module) {
    this.module = module;
  }

  @Override
  public OkHttpClient get() {
    return Preconditions.checkNotNull(
        module.provideOkHttpClient(), "Cannot return null from a non-@Nullable @Provides method");
  }

  public static Factory<OkHttpClient> create(NetworkModule module) {
    return new NetworkModule_ProvideOkHttpClientFactory(module);
  }
}
```

### After 

```
public final class NetworkModule_ProvideOkHttpClientFactory implements Factory<OkHttpClient> {
  private static final NetworkModule_ProvideOkHttpClientFactory INSTANCE =
      new NetworkModule_ProvideOkHttpClientFactory();

  @Override
  public OkHttpClient get() {
    return Preconditions.checkNotNull(
        NetworkModule.provideOkHttpClient(),
        "Cannot return null from a non-@Nullable @Provides method");
  }

  public static Factory<OkHttpClient> create() {
    return INSTANCE;
  }
}
```

