### PR TITLE
Add includeFontPadding

### DIFF
--- a/app/src/main/res/layout/item_speech_session.xml
+++ b/app/src/main/res/layout/item_speech_session.xml
@@ -125,6 +125,7 @@
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="12dp"
                 android:ellipsize="end"
+                android:includeFontPadding="false"
                 android:maxLines="3"
                 android:text="@{session.desc}"
                 android:textAppearance="@style/TextAppearance.App.Caption"


### PR DESCRIPTION
## Issue
- close #99 

## Overview (Required)
- TextView is off on some devices.
- Add `includeFontPadding="false"` option.

## Links
- https://stackoverflow.com/questions/39944535/android-textview-with-ellipsize-attribute-moved-from-the-original-position

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5153307/34906770-10c48c46-f8b7-11e7-9054-add404f63cf2.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5153307/34906771-1b23f4ec-f8b7-11e7-9805-0c24c8fc820d.png" width="300" />
