### PR TITLE
Delete language resources that are not Japanese and English

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,6 +17,7 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
+        resConfigs "en", "ja"
 
         javaCompileOptions {
             annotationProcessorOptions {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Delete language resources that are not Japanese and English by resConfigs
- Support libraries include resources other than Japanese and English
- Effect : Reduce apk size

## Links
- https://qiita.com/tatsuhama/items/814471b79c5d572f77e9

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
