### PR TITLE
Impl gradle task dependencyUpdates 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: "org.jlleitschuh.gradle.ktlint"
 apply plugin: 'io.fabric'
+apply plugin: 'com.github.ben-manes.versions'
 
 android {
     compileSdkVersion 27

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath 'com.google.gms:google-services:3.1.0'
         classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.0.0"
         classpath 'io.fabric.tools:gradle:1.25.1'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
     }
 }
 


### PR DESCRIPTION
## Issue
- close #113

## Overview (Required)
add gradle task
<details>
  <summary> ./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=xml </summary>

```
./gradlew dependencyUpdates -Drevision=release -DoutputFormatter=xml

> Configure project :app
Configuration 'compile' in project ':app' is deprecated. Use 'implementation' instead.
The CompileOptions.bootClasspath property has been deprecated and is scheduled to be removed in Gradle 5.0. Please use the CompileOptions.bootstrapClasspath property instead.
registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedFolders(FileCollection)
app: 'androidProcessor' dependencies won't be recognized as kapt annotation processors. Please change the configuration name to 'kapt' for these artifacts: 'com.android.databinding:compiler:3.0.1'.

> Task :app:dependencyUpdates

------------------------------------------------------------
:app Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest release version:
 - com.squareup.retrofit2:adapter-rxjava2:2.3.0
 - com.android.support:appcompat-v7:27.0.2
 - com.willowtreeapps.assertk:assertk:0.9
 - com.android.support:cardview-v7:27.0.2
 - android.arch.persistence.room:compiler:1.0.0
 - com.android.support.constraint:constraint-layout:1.1.0-beta4
 - com.squareup.retrofit2:converter-moshi:2.3.0
 - com.android.support:design:27.0.2
 - com.github.takahirom.downloadable.calligraphy:downloadable-calligraphy:0.1.2
 - android.arch.lifecycle:extensions:1.0.0
 - com.xwray:groupie-databinding:2.0.0
 - junit:junit:4.12
 - com.github.shyiko:ktlint:0.14.0
 - com.squareup.leakcanary:leakcanary-android:1.5.4
 - com.squareup.okhttp3:logging-interceptor:3.9.1
 - com.nhaarman:mockito-kotlin:1.5.0
 - com.android.support:multidex:1.0.2
 - com.android.support:multidex-instrumentation:1.0.2
 - android.arch.lifecycle:reactivestreams:1.0.0
 - com.squareup.retrofit2:retrofit:2.3.0
 - android.arch.lifecycle:runtime:1.0.3
 - android.arch.persistence.room:runtime:1.0.0
 - io.reactivex.rxjava2:rxandroid:2.0.1
 - android.arch.persistence.room:rxjava2:1.0.0
 - io.reactivex.rxjava2:rxkotlin:2.2.0
 - com.facebook.stetho:stetho:1.5.0
 - com.facebook.stetho:stetho-okhttp3:1.5.0
 - com.android.support:support-v4:27.0.2
 - com.android.support:support-vector-drawable:27.0.2
 - com.jakewharton.threetenabp:threetenabp:1.0.5
 - com.jakewharton.timber:timber:4.6.0

The following dependencies have later release versions:
 - com.android.databinding:adapters [1.3.1 -> 3.1.0-alpha08]
 - se.ansman.kotshi:api [0.3.0-beta1 -> 0.3.0]
 - com.android.databinding:baseLibrary [3.0.1 -> 3.1.0-alpha08]
 - com.android.databinding:compiler [3.0.1 -> 3.1.0-alpha08]
 - com.github.bumptech.glide:compiler [4.4.0 -> 4.5.0]
 - se.ansman.kotshi:compiler [0.3.0-beta1 -> 0.3.0]
 - com.crashlytics.sdk.android:crashlytics [2.7.1 -> 2.8.0]
 - com.google.dagger:dagger [2.13 -> 2.14.1]
 - com.google.dagger:dagger-android [2.13 -> 2.14.1]
 - com.google.dagger:dagger-android-processor [2.13 -> 2.14.1]
 - com.google.dagger:dagger-android-support [2.13 -> 2.14.1]
 - com.google.dagger:dagger-compiler [2.13 -> 2.14.1]
 - com.android.support.test.espresso:espresso-core [3.0.1 -> 3.0.2-alpha1]
 - com.google.firebase:firebase-auth [11.4.2 -> 11.8.0]
 - com.google.firebase:firebase-core [11.4.2 -> 11.8.0]
 - com.google.firebase:firebase-firestore [11.4.2 -> 11.8.0]
 - com.github.bumptech.glide:glide [4.4.0 -> 4.5.0]
 - com.xwray:groupie [2.0.0 -> 2.0.1]
 - org.jetbrains.kotlin:kotlin-annotation-processing-gradle [1.2.0 -> 1.2.10]
 - org.jetbrains.kotlin:kotlin-stdlib-jre7 [1.2.0 -> 1.2.10]
 - com.android.databinding:library [1.3.1 -> 3.1.0-alpha08]
 - com.github.bumptech.glide:okhttp3-integration [4.4.0 -> 4.5.0]
 - org.jacoco:org.jacoco.agent [0.7.4.201502262128 -> 0.8.0]
 - org.jacoco:org.jacoco.ant [0.7.4.201502262128 -> 0.8.0]
 - org.robolectric:robolectric [3.5.1 -> 3.6.1]
 - com.android.support.test:runner [1.0.1 -> 1.0.2-alpha1]
 - io.reactivex.rxjava2:rxjava [2.1.6 -> 2.1.8]
 - org.threeten:threetenbp [1.3.3 -> 1.3.6]

Generated report file build/dependencyUpdates/report.xml


BUILD SUCCESSFUL in 1s
1 actionable task: 1 executed
```
</details>


## Links
- none

## Screenshot
- none