### PR TITLE
Wrong argument count 'R.string.time_period'

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateHeaderItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateHeaderItem.kt
@@ -14,8 +14,7 @@ data class DateHeaderItem(
         viewBinding.periodText.text = viewBinding.root.context.getString(
                 R.string.time_period,
                 startDateTimePair.time,
-                endDateTimePair.time,
-                ""
+                endDateTimePair.time
         )
     }
 


### PR DESCRIPTION
`R.string.time_period` requires '2' argument count, but format call supplies '3'

## Issue
- none

## Overview (Required)
- `time_period` has 2 parameters, but it calls with 3 parameters

## Links
- https://github.com/DroidKaigi/conference-app-2018/blob/master/app/src/main/res/values/strings.xml#L3
- https://github.com/DroidKaigi/conference-app-2018/blob/master/app/src/main/res/values-ja/strings.xml#L3

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
