### PR TITLE
fix broken layout in speaker area on the search tab

### DIFF
--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -14,7 +14,7 @@
 
     <android.support.v7.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="156dp"
+        android:layout_height="166dp"
         android:layout_marginBottom="4dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
@@ -85,12 +85,12 @@
             <TextView
                 android:id="@+id/title"
                 android:layout_width="0dp"
-                android:layout_height="wrap_content"
+                android:layout_height="62dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="10dp"
-                android:lines="2"
                 android:lineSpacingExtra="@dimen/session_title_line_spacing"
+                android:lines="2"
                 android:text="@{session.title}"
                 android:textAppearance="@style/TextAppearance.App.Title"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -202,6 +202,7 @@
                 app:colorTint="@{session.isFavorited ? @color/accent : @color/sub_icon_color}"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/divider_top"
                 app:srcCompat="@{session.isFavorited ? @drawable/ic_favorite_black_24dp : @drawable/ic_favorite_border_black_24dp}"
                 tools:src="@drawable/ic_favorite_black_24dp"
                 />


### PR DESCRIPTION
## Issue
- nothing

## Overview (Required)
- Speaker area layout is broken if change font size.
- I fixed it in layout.

## Links
- nothing

## Screenshot
Before | After
:--: | :--:
|![before_small](https://user-images.githubusercontent.com/19305363/34908016-3a37be62-f8cc-11e7-953d-1d559fee9dbd.png)|![after_small](https://user-images.githubusercontent.com/19305363/34908026-577e2ef2-f8cc-11e7-9f6a-065c2a3763a4.png)|
|![before_large](https://user-images.githubusercontent.com/19305363/34908019-4326e020-f8cc-11e7-8392-09ef4121db15.png)|![after_large](https://user-images.githubusercontent.com/19305363/34908029-69bb43b6-f8cc-11e7-809d-19b7350cf171.png)|
<img src="" width="300" /> | <img src="" width="300" />
