### PR TITLE
Fix drawer to close when pressed back key

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -69,6 +69,12 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     enum class BottomNavigationItem(
             @MenuRes val menuId: Int,
             @DrawableRes val imageRes: Int?,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/about/AboutThisAppActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/about/AboutThisAppActivity.kt
@@ -37,6 +37,12 @@ class AboutThisAppActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         fun start(context: Context) {
             context.startActivity(Intent(context, AboutThisAppActivity::class.java))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2018.presentation.common.menu
 
 import android.support.design.widget.NavigationView
+import android.support.v4.view.GravityCompat
 import android.support.v4.widget.DrawerLayout
 import android.support.v7.app.ActionBarDrawerToggle
 import android.support.v7.app.AppCompatActivity
@@ -13,12 +14,15 @@ class DrawerMenu @Inject constructor(
         private val activity: AppCompatActivity,
         private val navigationController: NavigationController
 ) {
+    private lateinit var drawerLayout: DrawerLayout
+
     fun setup(
             toolbar: Toolbar,
             drawerLayout: DrawerLayout,
             navigationView: NavigationView,
             actionBarDrawerSync: Boolean = false
     ) {
+        this.drawerLayout = drawerLayout
         if (actionBarDrawerSync) {
             ActionBarDrawerToggle(
                     activity,
@@ -42,6 +46,15 @@ class DrawerMenu @Inject constructor(
                 R.id.nav_item_info -> navigationController.navigateToAboutThisAppActivity()
             }
             drawerLayout.closeDrawers()
+            true
+        }
+    }
+
+    fun closeDrawerIfNeeded(): Boolean {
+        return if (drawerLayout.isDrawerOpen(GravityCompat.START)) {
+            drawerLayout.closeDrawers()
+            false
+        } else {
             true
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailActivity.kt
@@ -104,6 +104,12 @@ class SessionDetailActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     class SessionDetailFragmentPagerAdapter(
             fragmentManager: FragmentManager
     ) : FragmentStatePagerAdapter(fragmentManager) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/map/MapActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/map/MapActivity.kt
@@ -36,6 +36,12 @@ class MapActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         fun start(context: Context) {
             context.startActivity(Intent(context, MapActivity::class.java))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/settings/SettingsActivity.kt
@@ -36,6 +36,12 @@ class SettingsActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         fun start(context: Context) {
             context.startActivity(Intent(context, SettingsActivity::class.java))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailActivity.kt
@@ -40,6 +40,12 @@ class SpeakerDetailActivity : AppCompatActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         const val EXTRA_SPEAKER_ID = "EXTRA_SPEAKER_ID"
         fun start(context: Context, speakerId: String) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sponsors/SponsorsActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sponsors/SponsorsActivity.kt
@@ -36,6 +36,12 @@ class SponsorsActivity : BaseActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     companion object {
         fun start(context: Context) {
             context.startActivity(Intent(context, SponsorsActivity::class.java))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/topic/TopicDetailActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/topic/TopicDetailActivity.kt
@@ -61,6 +61,12 @@ class TopicDetailActivity : AppCompatActivity(), HasSupportFragmentInjector {
 
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
     private fun updateAppBarLayout(topic: Topic, total: Int) {
         binding.total = resources.getQuantityString(R.plurals.topic_total_session, total, total)
         if (lang() == Lang.JA) {


### PR DESCRIPTION
## Issue
none

## Overview (Required)
When I press the back button while `DrawerLayout` is opened, the screen closes immediately.
I fixed it to close only `DrawerLayout`.

## Links
none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/34909408-9bcf1bb8-f8e3-11e7-9fc1-060b7afded10.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/34909411-a2366420-f8e3-11e7-8990-27f10d128ca8.gif" width="300" />

