### PR TITLE
Modify speaker search layout #148

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSpeakersFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSpeakersFragment.kt
@@ -4,6 +4,8 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v7.widget.DividerItemDecoration
+import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -69,6 +71,8 @@ class SearchSpeakersFragment : Fragment(), Injectable {
         binding.searchSessionRecycler.apply {
             adapter = groupAdapter
         }
+        binding.searchSessionRecycler.addItemDecoration(DividerItemDecoration(context,
+                LinearLayoutManager(activity).orientation))
     }
 
     companion object {

--- a/app/src/main/res/layout/fragment_search_speakers.xml
+++ b/app/src/main/res/layout/fragment_search_speakers.xml
@@ -16,6 +16,8 @@
             android:id="@+id/search_session_recycler"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="16dp"
             android:orientation="vertical"
             app:layoutManager="android.support.v7.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/item_speaker.xml
+++ b/app/src/main/res/layout/item_speaker.xml
@@ -20,7 +20,7 @@
             android:layout_width="@{@dimen/search_speaker_image_size, default=@dimen/search_speaker_image_size}"
             android:layout_height="@{@dimen/search_speaker_image_size, default=@dimen/search_speaker_image_size}"
             android:layout_marginBottom="8dp"
-            android:layout_marginStart="8dp"
+            android:layout_marginStart="16dp"
             android:layout_marginTop="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Issue
- close #148 

## Overview (Required)
- Modify speaker search layout
  - add divider
  - add margin `16dp` on the top and bottom of recyclerview
  - change marginLeft `8dp` -> `16dp`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
<img width="300" alt="2018-01-14 13 44 36" src="https://user-images.githubusercontent.com/15154826/34912917-24e807fa-f931-11e7-85e5-7d1947989e3e.png">|<img width="300" alt="2018-01-14 13 49 42" src="https://user-images.githubusercontent.com/15154826/34912934-e0020c66-f931-11e7-9785-7f9301df40e0.png">
