### PR TITLE
fix toolbar title cut off

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -14,7 +14,7 @@
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.ActionBar">
         <item name="colorControlNormal">@color/app_bar_text_color</item>
-        <item name="android:includeFontPadding">false</item>
+        <item name="android:lineSpacingExtra">@dimen/session_title_line_spacing</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- toolbar title cut off

## Links
- none

## Screenshot  
Before | After
:--: | :--:
![device-2018-01-14-164002](https://user-images.githubusercontent.com/11572021/34913861-c83b1cda-f94a-11e7-9795-366152b826ea.png) | ![device-2018-01-14-163657](https://user-images.githubusercontent.com/11572021/34913864-cdfedecc-f94a-11e7-9565-b7ff4e298d40.png)

<img src="" width="300" /> | <img src="" width="300" />
bottom of 'y'