### PR TITLE
Update lint.xml for ignore color resources unused.

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="MissingTranslation" severity="warning" />
+    <issue id="UnusedResources">
+        <ignore path="res/values/colors.xml" />
+    </issue>
 </lint>


### PR DESCRIPTION
## Issue
- close #152

## Overview (Required)
- Some color resources referenced from other resources were detected as unused.
- I update lint.xml for ignore color resources unused.

## Links
- https://github.com/DroidKaigi/conference-app-2018/pull/168
- https://developer.android.com/studio/write/lint.html#config

## Screenshot

<img src="https://user-images.githubusercontent.com/3457369/34914001-95300d3e-f94d-11e7-9f4a-67363a48aea4.png" width="300" />
