### PR TITLE
Fixed there is no need to display day header view

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
@@ -68,6 +68,7 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
                     sessionsSection.updateSessions(
                             sessions, onFavoriteClickListener, simplify = true)
                     binding.mysessionInactiveGroup.setVisible(sessions.isEmpty())
+                    binding.sessionsRecycler.setVisible(sessions.isNotEmpty())
                 }
                 is Result.Failure -> {
                     Timber.e(result.e)


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- When no mysession is registered and scroll down then a empty day header view was displayed.


## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1450486/34914232-d4f5e4e4-f951-11e7-8d70-79ecc62274d9.png" width="300" /> | none

