### PR TITLE
Replace explicit parameter with it

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
@@ -27,8 +27,8 @@ fun List<Session>?.toSessionEntities(
         categories: List<Category>?,
         rooms: List<Room>?
 ): List<SessionEntity> =
-        this!!.map { responseSession ->
-            responseSession.toSessionEntity(categories, rooms)
+        this!!.map {
+            it.toSessionEntity(categories, rooms)
         }
 
 fun Session.toSessionEntity(categories: List<Category>?, rooms: List<Room>?): SessionEntity {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -69,8 +69,8 @@ class SessionDataRepository @Inject constructor(
 
     override val speakers: Flowable<List<Speaker>> =
             sessionDatabase.getAllSpeaker()
-                    .map { speakers ->
-                        speakers.map { speaker -> speaker.toSpeaker() }
+                    .map {
+                        it.map { speaker -> speaker.toSpeaker() }
                     }
 
     override val roomSessions: Flowable<Map<Room, List<Session>>> =

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
@@ -29,7 +29,7 @@ class AllSessionsViewModel @Inject constructor(
     }
 
     val isLoading: LiveData<Boolean> by lazy {
-        sessions.map { result -> result.inProgress }
+        sessions.map { it.inProgress }
     }
 
     fun onFavoriteClick(session: Session.SpeechSession) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
@@ -33,7 +33,7 @@ class RoomSessionsViewModel @Inject constructor(
                 .toLiveData()
     }
     val isLoading: LiveData<Boolean> by lazy {
-        sessions.map { result -> result.inProgress }
+        sessions.map { it.inProgress }
     }
 
     fun onFavoriteClick(session: Session.SpeechSession) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
@@ -29,7 +29,7 @@ class SessionsViewModel @Inject constructor(
                 .toLiveData()
     }
     val isLoading: LiveData<Boolean> by lazy {
-        rooms.map { result -> result.inProgress }
+        rooms.map { it.inProgress }
     }
     private val mutableRefreshState: MutableLiveData<Result<Unit>> = MutableLiveData()
     val refreshResult: LiveData<Result<Unit>> = mutableRefreshState


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Replace explicit parameter with `it` in ViewModels, repository, and mapper for refactoring.

## Links
- none

## Screenshot
none