### PR TITLE
Avoid mutable in result property in SearchViewModel

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchViewModel.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2018.presentation.search
 
-import android.arch.lifecycle.LifecycleObserver
+import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
@@ -20,7 +20,9 @@ class SearchViewModel @Inject constructor(
         private val repository: SessionRepository,
         private val schedulerProvider: SchedulerProvider
 ) : ViewModel() {
-    val result: MutableLiveData<Result<SearchResult>> = MutableLiveData()
+    private val mutableResult = MutableLiveData<Result<SearchResult>>()
+    val result: LiveData<Result<SearchResult>> = mutableResult
+
     var searchQuery: String = ""
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
 
@@ -28,7 +30,7 @@ class SearchViewModel @Inject constructor(
         repository.search(query)
                 .toResult(schedulerProvider)
                 .subscribe {
-                    result.value = it
+                    mutableResult.value = it
                     searchQuery = query
                 }
                 .addTo(compositeDisposable)


### PR DESCRIPTION
## Overview (Required)

I'm accessibility police 👮 .
``result`` property no need "mutable" because it's one way bindable property. 👍 
