### PR TITLE
Kotshi automatically checks non-null, nullable of response properties

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/Session.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/Session.kt
@@ -5,7 +5,7 @@ import se.ansman.kotshi.JsonSerializable
 
 @JsonSerializable
 data class Session(
-        val id: String?,
+        val id: String,
         val isServiceSession: Boolean?,
         val isPlenumSession: Boolean?,
         val speakers: List<String?>?,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
@@ -37,7 +37,7 @@ fun Session.toSessionEntity(categories: List<Category>?, rooms: List<Room>?): Se
     val topic = categories.category(2, categoryItems[2])
     val level = categories.category(3, categoryItems[3])
     return SessionEntity(
-            id = id!!,
+            id = id,
             title = title!!,
             desc = description!!,
             stime = startsAt!!,


### PR DESCRIPTION
## Overview (Required)
I think `response.Session#id` is a non-null property as long as I read the source code, and response.Session used Kotshi.

If we are using Kotshi, it may be better to make the non-null property non-null.
Because, when null is returned from the server, `KotshiSessionJsonAdapter` generated automatically by Kotshi performs a null check and it will give an error at the timing of parsing json.

I think that it is easier to develop if we know nullable and non-null in response.Session property rather than attaching `!!` when converting with Session.toSessionEntity?

If that is not a problem, I will try to fix another property of the response.Session in this pull-request.
