### PR TITLE
Make Converters class to object

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/Converters.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/Converters.kt
@@ -6,20 +6,18 @@ import org.threeten.bp.LocalDateTime
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
 
-class Converters {
-    companion object {
-        @JvmStatic
-        @TypeConverter
-        fun fromTimestamp(value: Long?): LocalDateTime? {
-            if (value == null) {
-                return null
-            }
-            return LocalDateTime.ofInstant(Instant.ofEpochSecond(value), ZoneId.systemDefault())
+object Converters {
+    @JvmStatic
+    @TypeConverter
+    fun fromTimestamp(value: Long?): LocalDateTime? {
+        if (value == null) {
+            return null
         }
-
-        @JvmStatic
-        @TypeConverter
-        fun dateToTimestamp(date: LocalDateTime?): Long? =
-                date?.toEpochSecond(ZoneOffset.ofHours(9))
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(value), ZoneId.systemDefault())
     }
+
+    @JvmStatic
+    @TypeConverter
+    fun dateToTimestamp(date: LocalDateTime?): Long? =
+            date?.toEpochSecond(ZoneOffset.ofHours(9))
 }


### PR DESCRIPTION
## Issue
None

## Overview (Required)
- Make `Converters` class to object

This change deletes `Converters.Companion`

class

```
public final class Converters {
   public static final Converters.Companion Companion = new Converters.Companion((DefaultConstructorMarker)null);

   @JvmStatic
   @TypeConverter
   @Nullable
   public static final LocalDateTime fromTimestamp(@Nullable Long value) {
      return Companion.fromTimestamp(value);
   }

   @JvmStatic
   @TypeConverter
   @Nullable
   public static final Long dateToTimestamp(@Nullable LocalDateTime date) {
      return Companion.dateToTimestamp(date);
   }

   @Metadata(
      mv = {1, 1, 9},
      bv = {1, 0, 2},
      k = 1,
      d1 = {"\u0000\u001a\n\u0002\u0018\u0002\n\u0002\u0010\u0000\n\u0002\b\u0002\n\u0002\u0010\t\n\u0000\n\u0002\u0018\u0002\n\u0002\b\u0005\b\u0086\u0003\u0018\u00002\u00020\u0001B\u0007\b\u0002¢\u0006\u0002\u0010\u0002J\u0019\u0010\u0003\u001a\u0004\u0018\u00010\u00042\b\u0010\u0005\u001a\u0004\u0018\u00010\u0006H\u0007¢\u0006\u0002\u0010\u0007J\u0019\u0010\b\u001a\u0004\u0018\u00010\u00062\b\u0010\t\u001a\u0004\u0018\u00010\u0004H\u0007¢\u0006\u0002\u0010\n¨\u0006\u000b"},
      d2 = {"Lio/github/droidkaigi/confsched2018/data/db/entity/mapper/Converters$Companion;", "", "()V", "dateToTimestamp", "", "date", "Lorg/threeten/bp/LocalDateTime;", "(Lorg/threeten/bp/LocalDateTime;)Ljava/lang/Long;", "fromTimestamp", "value", "(Ljava/lang/Long;)Lorg/threeten/bp/LocalDateTime;", "production sources for module app"}
   )
   public static final class Companion {
      @JvmStatic
      @TypeConverter
      @Nullable
      public final LocalDateTime fromTimestamp(@Nullable Long value) {
         return value == null?null:LocalDateTime.ofInstant(Instant.ofEpochSecond(value.longValue()), ZoneId.systemDefault());
      }

      @JvmStatic
      @TypeConverter
      @Nullable
      public final Long dateToTimestamp(@Nullable LocalDateTime date) {
         return date != null?Long.valueOf(date.toEpochSecond(ZoneOffset.ofHours(9))):null;
      }

      private Companion() {
      }

      // $FF: synthetic method
      public Companion(DefaultConstructorMarker $constructor_marker) {
         this();
      }
   }
}
```

object

```
public final class Converters {
   public static final Converters INSTANCE;

   @JvmStatic
   @TypeConverter
   @Nullable
   public static final LocalDateTime fromTimestamp(@Nullable Long value) {
      return value == null?null:LocalDateTime.ofInstant(Instant.ofEpochSecond(value.longValue()), ZoneId.systemDefault());
   }

   @JvmStatic
   @TypeConverter
   @Nullable
   public static final Long dateToTimestamp(@Nullable LocalDateTime date) {
      return date != null?Long.valueOf(date.toEpochSecond(ZoneOffset.ofHours(9))):null;
   }

   static {
      Converters var0 = new Converters();
      INSTANCE = var0;
   }
}
```


## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
