### PR TITLE
Remove redundant classpath definition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
         classpath 'com.google.gms:google-services:3.1.0'
         classpath "gradle.plugin.org.jlleitschuh.gradle:ktlint-gradle:3.0.0"
         classpath 'io.fabric.tools:gradle:1.25.1'


### PR DESCRIPTION
## Overview (Required)

This classpath definition is redundant 👀 
```
'com.github.ben-manes:gradle-versions-plugin:0.17.0'
```


