### PR TITLE
Add space between the number and 'session'

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,8 +61,8 @@
 
     <!-- Topic -->
     <plurals name="topic_total_session">
-        <item quantity="zero">%dsession</item>
-        <item quantity="one">%dsession</item>
-        <item quantity="other">%dsessions</item>
+        <item quantity="zero">%d session</item>
+        <item quantity="one">%d session</item>
+        <item quantity="other">%d sessions</item>
     </plurals>
 </resources>


### PR DESCRIPTION
## Overview (Required)
- Adding a space between the number and 'session'

I feel this makes easier to read. How do you think?

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/819673/34936987-951a7062-fa26-11e7-9e82-17a84f266e02.png" width="300" /> | <img src="https://user-images.githubusercontent.com/819673/34937006-a084bb2e-fa26-11e7-8339-3554c0422572.png" width="300" />
