### PR TITLE
Set empty reselected listener to BottomNavigationView

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -62,6 +62,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
             navigationItem.navigate(navigationController)
             true
         })
+        binding.bottomNavigation.setOnNavigationItemReselectedListener {  }
         if (savedInstanceState == null) {
             binding.bottomNavigation.selectedItemId = R.id.navigation_sessions
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -62,7 +62,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
             navigationItem.navigate(navigationController)
             true
         })
-        binding.bottomNavigation.setOnNavigationItemReselectedListener {  }
+        binding.bottomNavigation.setOnNavigationItemReselectedListener { }
         if (savedInstanceState == null) {
             binding.bottomNavigation.selectedItemId = R.id.navigation_sessions
         }


### PR DESCRIPTION
## Overview (Required)
- Set empty reselected listener to BottomNavigationView

To prevent unnecessary fragment recreation, set empty listener to
BottomNavigationView#setOnNavigationItemReselectedListener.
if a non-null re-selected listener is set, the selected listener doesn't be called by
re-selection.

I prefer scrolling to the top action like YouTube app. However, it seems to conflict with #65.
Therefore I just set empty listener in this PR.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/819673/34941332-a9da4fa8-fa36-11e7-836e-6d0e5934f750.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/819673/34941351-b2ce9d44-fa36-11e7-9643-114990e53203.gif" width="300" />
