### PR TITLE
Avoid unnecessary update for PagerAdapter

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -118,6 +118,9 @@ class SessionsViewPagerAdapter(
     override fun getCount(): Int = tabs.size
 
     fun setRooms(rooms: List<Room>) {
+        if (rooms == roomTabs.map { it.room }) {
+            return
+        }
         roomTabs = rooms.map {
             Tab.RoomTab(it)
         }.toMutableList()


### PR DESCRIPTION
## Overview (Required)

To prevent unnecessary invocation of `notifyDataSetChanged`. PagerAdapter's notifyDataSetChanged
invoke `requestlayout`.
Users may be surprised at unexpected layout updates.


## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/937552/34949392-54f2f81a-fa53-11e7-8789-967f1ae1d09d.gif)|![after](https://user-images.githubusercontent.com/937552/34949398-5b273cfa-fa53-11e7-9a17-57dc1efe569f.gif)

Please look `TabLayout`. Before's font size is modified on update. After's fixed it.