### PR TITLE
Remove unnecessary plural element

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,6 @@
 
     <!-- Topic -->
     <plurals name="topic_total_session">
-        <item quantity="zero">%d session</item>
         <item quantity="one">%d session</item>
         <item quantity="other">%d sessions</item>
     </plurals>


### PR DESCRIPTION
## Issue
None

## Overview (Required)
This plural element is unnecessary in English.
```
<item quantity="zero">%d session</item>
```
The plural form of Android follows the rule below, so "zero" element is unnecessary in English.

## Links
- http://www.unicode.org/cldr/charts/latest/supplemental/language_plural_rules.html#en
