### PR TITLE
[WIP]Fix build error on release

### DIFF
--- a/app/src/debug/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/debug/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -1,22 +1,10 @@
 package io.github.droidkaigi.confsched2018.di
 
 import com.facebook.stetho.okhttp3.StethoInterceptor
-import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
-import io.github.droidkaigi.confsched2018.data.api.DroidKaigiApi
-import io.github.droidkaigi.confsched2018.data.api.FeedApi
-import io.github.droidkaigi.confsched2018.data.api.FeedFirestoreApi
-import io.github.droidkaigi.confsched2018.data.api.GithubApi
-import io.github.droidkaigi.confsched2018.data.api.SessionFeedbackApi
-import io.github.droidkaigi.confsched2018.data.api.response.mapper.ApplicationJsonAdapterFactory
-import io.github.droidkaigi.confsched2018.data.api.response.mapper.LocalDateTimeAdapter
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
-import org.threeten.bp.LocalDateTime
-import retrofit2.Retrofit
-import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
-import retrofit2.converter.moshi.MoshiConverterFactory
 import javax.inject.Singleton
 
 @Module internal object NetworkModule {
@@ -27,61 +15,4 @@ import javax.inject.Singleton
                     .setLevel(HttpLoggingInterceptor.Level.BODY))
             .addNetworkInterceptor(StethoInterceptor())
             .build()
-
-    @RetrofitDroidKaigi @Singleton @Provides @JvmStatic
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
-        return Retrofit.Builder()
-                .client(okHttpClient)
-                .baseUrl("https://droidkaigi.jp/2018/sessionize/")
-                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
-                        .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
-                        .build()))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
-                .build()
-    }
-
-    @RetrofitGoogleForm @Singleton @Provides @JvmStatic
-    fun provideRetrofitForGoogleForm(okHttpClient: OkHttpClient): Retrofit {
-        return Retrofit.Builder()
-                .client(okHttpClient)
-                .baseUrl("https://docs.google.com/forms/d/")
-                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
-                        .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
-                        .build()))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
-                .build()
-    }
-
-    @RetrofitGithub @Singleton @Provides @JvmStatic
-    fun provideRetrofitForGithub(okHttpClient: OkHttpClient): Retrofit {
-        return Retrofit.Builder()
-                .baseUrl("https://api.github.com")
-                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
-                        .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
-                        .build()))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
-                .client(okHttpClient)
-                .build()
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideDroidKaigiApi(@RetrofitDroidKaigi retrofit: Retrofit): DroidKaigiApi {
-        return retrofit.create(DroidKaigiApi::class.java)
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideFeedApi(): FeedApi = FeedFirestoreApi()
-
-    @Singleton @Provides @JvmStatic
-    fun provideSessionFeedbackApi(@RetrofitGoogleForm retrofit: Retrofit): SessionFeedbackApi {
-        return retrofit.create(SessionFeedbackApi::class.java)
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideGithubApi(@RetrofitGithub retrofit: Retrofit): GithubApi {
-        return retrofit.create(GithubApi::class.java)
-    }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/ApiModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/ApiModule.kt
@@ -1,0 +1,78 @@
+package io.github.droidkaigi.confsched2018.di
+
+import com.squareup.moshi.Moshi
+import dagger.Module
+import dagger.Provides
+import io.github.droidkaigi.confsched2018.data.api.DroidKaigiApi
+import io.github.droidkaigi.confsched2018.data.api.FeedApi
+import io.github.droidkaigi.confsched2018.data.api.FeedFirestoreApi
+import io.github.droidkaigi.confsched2018.data.api.GithubApi
+import io.github.droidkaigi.confsched2018.data.api.SessionFeedbackApi
+import io.github.droidkaigi.confsched2018.data.api.response.mapper.ApplicationJsonAdapterFactory
+import io.github.droidkaigi.confsched2018.data.api.response.mapper.LocalDateTimeAdapter
+import okhttp3.OkHttpClient
+import org.threeten.bp.LocalDateTime
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module internal object ApiModule {
+
+    @RetrofitDroidKaigi @Singleton @Provides @JvmStatic
+    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+                .client(okHttpClient)
+                .baseUrl("https://droidkaigi.jp/2018/sessionize/")
+                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
+                        .add(ApplicationJsonAdapterFactory.INSTANCE)
+                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .build()))
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
+                .build()
+    }
+
+    @RetrofitGoogleForm @Singleton @Provides @JvmStatic
+    fun provideRetrofitForGoogleForm(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+                .client(okHttpClient)
+                .baseUrl("https://docs.google.com/forms/d/")
+                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
+                        .add(ApplicationJsonAdapterFactory.INSTANCE)
+                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .build()))
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
+                .build()
+    }
+
+    @RetrofitGithub @Singleton @Provides @JvmStatic
+    fun provideRetrofitForGithub(okHttpClient: OkHttpClient): Retrofit {
+        return Retrofit.Builder()
+                .baseUrl("https://api.github.com")
+                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
+                        .add(ApplicationJsonAdapterFactory.INSTANCE)
+                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .build()))
+                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
+                .client(okHttpClient)
+                .build()
+    }
+
+    @Singleton @Provides @JvmStatic
+    fun provideDroidKaigiApi(@RetrofitDroidKaigi retrofit: Retrofit): DroidKaigiApi {
+        return retrofit.create(DroidKaigiApi::class.java)
+    }
+
+    @Singleton @Provides @JvmStatic
+    fun provideFeedApi(): FeedApi = FeedFirestoreApi()
+
+    @Singleton @Provides @JvmStatic
+    fun provideSessionFeedbackApi(@RetrofitGoogleForm retrofit: Retrofit): SessionFeedbackApi {
+        return retrofit.create(SessionFeedbackApi::class.java)
+    }
+
+    @Singleton @Provides @JvmStatic
+    fun provideGithubApi(@RetrofitGithub retrofit: Retrofit): GithubApi {
+        return retrofit.create(GithubApi::class.java)
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppComponent.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppComponent.kt
@@ -12,6 +12,7 @@ import javax.inject.Singleton
     AndroidInjectionModule::class,
     AppModule::class,
     NetworkModule::class,
+    ApiModule::class,
     DatabaseModule::class,
     MainActivityBuilder::class,
     MapActivityBuilder::class,

--- a/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -44,4 +44,14 @@ import javax.inject.Singleton
 
     @Singleton @Provides @JvmStatic
     fun provideFeedApi(): FeedApi = FeedFirestoreApi()
+
+    @Singleton @Provides @JvmStatic
+    fun provideSessionFeedbackApi(@RetrofitGoogleForm retrofit: Retrofit): SessionFeedbackApi {
+        return retrofit.create(SessionFeedbackApi::class.java)
+    }
+
+    @Singleton @Provides @JvmStatic
+    fun provideGithubApi(@RetrofitGithub retrofit: Retrofit): GithubApi {
+        return retrofit.create(GithubApi::class.java)
+    }
 }

--- a/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/release/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -23,35 +23,4 @@ import javax.inject.Singleton
             .addNetworkInterceptor(HttpLoggingInterceptor()
                     .setLevel(HttpLoggingInterceptor.Level.BASIC))
             .build()
-
-    @Singleton @Provides @JvmStatic
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
-        return Retrofit.Builder()
-                .client(okHttpClient)
-                .baseUrl("https://droidkaigi.jp/2018/sessionize/")
-                .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
-                        .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
-                        .build()))
-                .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
-                .build()
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideDroidKaigiApi(retrofit: Retrofit): DroidKaigiApi {
-        return retrofit.create(DroidKaigiApi::class.java)
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideFeedApi(): FeedApi = FeedFirestoreApi()
-
-    @Singleton @Provides @JvmStatic
-    fun provideSessionFeedbackApi(@RetrofitGoogleForm retrofit: Retrofit): SessionFeedbackApi {
-        return retrofit.create(SessionFeedbackApi::class.java)
-    }
-
-    @Singleton @Provides @JvmStatic
-    fun provideGithubApi(@RetrofitGithub retrofit: Retrofit): GithubApi {
-        return retrofit.create(GithubApi::class.java)
-    }
 }


### PR DESCRIPTION
## Issue
- NONE

## Overview (Required)
https://circleci.com/gh/DroidKaigi/conference-app-2018/400
```

e: /home/circleci/project/app/build/tmp/kapt3/stubs/release/io/github/droidkaigi/confsched2018/di/AppComponent.java:6: error: [dagger.android.AndroidInjector.inject(T)] io.github.droidkaigi.confsched2018.data.api.GithubApi cannot be provided without an @Provides-annotated method.
e: 

e: public abstract interface AppComponent {
e:                 ^
e:       io.github.droidkaigi.confsched2018.data.api.GithubApi is injected at
e:           io.github.droidkaigi.confsched2018.di.AppModule.provideContributorsRepository(api, …)
e:       io.github.droidkaigi.confsched2018.data.repository.ContributorRepository is injected at
e:           io.github.droidkaigi.confsched2018.presentation.contributor.ContributorsViewModel.<init>(repository, …)
e:       io.github.droidkaigi.confsched2018.presentation.contributor.ContributorsViewModel is injected at
e:           io.github.droidkaigi.confsched2018.di.ViewModelModule.bindContributorsViewModel(contributorsViewModel)
e:       java.util.Map<java.lang.Class<? extends android.arch.lifecycle.ViewModel>,javax.inject.Provider<android.arch.lifecycle.ViewModel>> is injected at
e:           io.github.droidkaigi.confsched2018.di.ViewModelFactory.<init>(creators)
e:       io.github.droidkaigi.confsched2018.di.ViewModelFactory is injected at
e:           io.github.droidkaigi.confsched2018.di.ViewModelModule.bindViewModelFactory(factory)
e:       android.arch.lifecycle.ViewModelProvider.Factory is injected at
e:           io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.viewModelFactory
e:       io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment is injected at
e:           dagger.android.AndroidInjector.inject(arg0)
```
