### PR TITLE
Fix crash in session detail screen

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
@@ -86,12 +86,14 @@ class SpeakersSummaryLayout @JvmOverloads constructor(
      *     app:speakers="@{speakers}"
      *     />
      */
-    fun setSpeakers(speakers: List<Speaker>) {
-        speakerList.clear()
-        speakerList.addAll(speakers)
+    fun setSpeakers(speakers: List<Speaker>?) {
+        speakers?.let {
+            speakerList.clear()
+            speakerList.addAll(speakers)
 
-        updateIcons()
-        updateText()
+            updateIcons()
+            updateText()
+        }
     }
 
     private fun updateIcons() {


### PR DESCRIPTION
## Issue
- close #196 

## Overview (Required)
- Fixed the parameter to allow null.

## Reproduction procedure
1. Turn on `Don't keep activities` in developer options.
2. Start app and show session detail screen.
3. Tap home button and return home screen.
4. Tap recent app button and choose this app.