### PR TITLE
Revert "Remove unnecessary plural element"

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
 
     <!-- Topic -->
     <plurals name="topic_total_session">
+        <item quantity="zero">%d session</item>
         <item quantity="one">%d session</item>
         <item quantity="other">%d sessions</item>
     </plurals>


### PR DESCRIPTION
Reverts DroidKaigi/conference-app-2018#210

I think it is better to have a `zero` quantity element because this resource is used for not only English but also many languages. 


These are simple examples. English always ignore `zero` element but Arabic can use `zero`.
In Arabic, If there is no `zero` element, `other` is used instead.

English | Arabic(チュニジア)
:--: | :--:
<img src="https://user-images.githubusercontent.com/819673/34994069-ba2c0a60-fb15-11e7-9fdf-87aee0573997.png" width="300" /> | <img src="https://user-images.githubusercontent.com/819673/34994089-c6e96a9a-fb15-11e7-8d43-7ca4aaee5321.png" width="300" />

sample app -> https://github.com/yaeda/android-plural-test