### PR TITLE
Fix contributor screen flash

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/ContributorsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/ContributorsFragment.kt
@@ -19,7 +19,6 @@ import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.common.binding.FragmentDataBindingComponent
-import io.github.droidkaigi.confsched2018.presentation.contributor.item.ContributorHeaderItem
 import io.github.droidkaigi.confsched2018.presentation.contributor.item.ContributorItem
 import io.github.droidkaigi.confsched2018.presentation.contributor.item.ContributorsSection
 import io.github.droidkaigi.confsched2018.util.ext.observe
@@ -51,9 +50,6 @@ class ContributorsFragment : Fragment(), Injectable {
             when (result) {
                 is Result.Success -> {
                     val contributors = result.data
-                    val header =
-                            ContributorHeaderItem(contributors.size, fragmentDataBindingComponent)
-                    contributorSection.setHeader(header)
                     contributorSection.updateContributors(contributors)
                 }
                 is Result.Failure -> {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorHeaderItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorHeaderItem.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2018.presentation.contributor.item
 
 import android.databinding.DataBindingUtil
 import android.view.View
+import com.xwray.groupie.Item
 import com.xwray.groupie.databinding.BindableItem
 import com.xwray.groupie.databinding.ViewHolder
 import io.github.droidkaigi.confsched2018.R
@@ -22,4 +23,12 @@ class ContributorHeaderItem(
     override fun bind(viewBinding: ItemContributorHeaderBinding, position: Int) {
         viewBinding.contributorCount = contributorCount
     }
+
+    override fun isSameAs(other: Item<*>?): Boolean =
+            other is ContributorHeaderItem
+
+    override fun equals(other: Any?): Boolean =
+            contributorCount == (other as? ContributorHeaderItem?)?.contributorCount
+
+    override fun hashCode(): Int = contributorCount
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorItem.kt
@@ -12,7 +12,7 @@ import io.github.droidkaigi.confsched2018.presentation.common.binding.FragmentDa
 data class ContributorItem(
         val contributor: Contributor,
         private val dataBindingComponent: FragmentDataBindingComponent
-) : BindableItem<ItemContributorBinding>() {
+) : BindableItem<ItemContributorBinding>(contributor.name.hashCode().toLong()) {
 
     override fun createViewHolder(itemView: View): ViewHolder<ItemContributorBinding> {
         return ViewHolder(DataBindingUtil.bind(itemView, dataBindingComponent))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/item/ContributorsSection.kt
@@ -9,7 +9,8 @@ class ContributorsSection(
         private val dataBindingComponent: FragmentDataBindingComponent
 ) : Section() {
     fun updateContributors(topics: List<Contributor>) {
-        val list = mutableListOf<Item<*>>()
+        val header = ContributorHeaderItem(topics.size, dataBindingComponent)
+        val list = mutableListOf<Item<*>>(header)
         topics.sortedByDescending { it.contributions }.mapTo(list) {
             ContributorItem(it, dataBindingComponent)
         }


### PR DESCRIPTION
## Issue
- close #223 

## Overview (Required)
- Specify the id (contributor's name hash) to Groupie `Item` constructor to support diff calculation.
- Use `Section#add` instead of `Section#setHeader` like `SessionHeaderItem` and `DateHeaderItem` since Groupie's diff calculation may fail.