### PR TITLE
Remove custom namespace from BindingAdapter definitions

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/FragmentBindingAdapters.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/FragmentBindingAdapters.kt
@@ -12,8 +12,8 @@ class FragmentBindingAdapters @Inject
 constructor(internal val fragment: Fragment) {
     @BindingAdapter(
             value = [
-                "bind:loadImage",
-                "bind:placeHolder",
+                "loadImage",
+                "placeHolder",
                 "android:layout_width",
                 "android:layout_height"
             ]

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/ImageBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/ImageBinding.kt
@@ -10,11 +10,11 @@ import android.widget.ImageView
 
 @BindingMethods(
         BindingMethod(type = ImageView::class,
-                attribute = "app:srcCompat",
+                attribute = "srcCompat",
                 method = "setImageDrawable"))
 class ImageBinding
 
-@BindingAdapter("bind:colorTint", "app:srcCompat")
+@BindingAdapter("colorTint", "srcCompat")
 fun ImageView.setColorTint(@ColorInt color: Int, drawable: Drawable) {
     val wrappedDrawable = DrawableCompat.wrap(drawable.mutate())
     DrawableCompat.setTint(wrappedDrawable, color)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -14,7 +14,7 @@ import io.github.droidkaigi.confsched2018.model.toReadableDateTimeString
 import io.github.droidkaigi.confsched2018.model.toReadableTimeString
 import java.util.regex.Pattern
 
-@BindingAdapter(value = ["bind:dayNumber"])
+@BindingAdapter(value = ["dayNumber"])
 fun TextView.setDayText(dayNumber: Int) {
     text = context.getString(
             R.string.session_day_title,
@@ -22,7 +22,7 @@ fun TextView.setDayText(dayNumber: Int) {
     )
 }
 
-@BindingAdapter(value = ["bind:startDate", "bind:endDate"])
+@BindingAdapter(value = ["startDate", "endDate"])
 fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
     startDate ?: return
     endDate ?: return
@@ -33,7 +33,7 @@ fun TextView.setPeriodText(startDate: Date?, endDate: Date?) {
     )
 }
 
-@BindingAdapter(value = ["bind:prefix", "bind:roomName"])
+@BindingAdapter(value = ["prefix", "roomName"])
 fun TextView.setRoomText(prefix: String?, roomName: String?) {
     prefix ?: return
     text = when (roomName) { null -> ""
@@ -47,7 +47,7 @@ fun TextView.setDateText(date: Date?) {
     text = date.toReadableDateTimeString()
 }
 
-@BindingAdapter(value = ["bind:highlightText"])
+@BindingAdapter(value = ["highlightText"])
 fun TextView.setHighlightText(highlightText: String?) {
     // By toString, clear highlight text.
     val stringBuilder = SpannableStringBuilder(text.toString())


### PR DESCRIPTION
## Issue
- close #215 

## Overview (Required)
- remove namespace from each binding adapter

## Links
- (none)

## Screenshot
- Before
<img width="1228" alt="2018-01-17 2 47 36" src="https://user-images.githubusercontent.com/12439154/35005225-1686aaf2-fb36-11e7-83de-4702c9d92ab4.png">

- After
<img width="1220" alt="2018-01-17 3 17 19" src="https://user-images.githubusercontent.com/12439154/35005240-20bf8ab6-fb36-11e7-8224-af1353b8439d.png">

Android Studio's MessageTab warnings disappeared 💪