### PR TITLE
Filtering empty rooms

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -32,6 +32,7 @@ class SessionDataRepository @Inject constructor(
 
     override val rooms: Flowable<List<Room>> =
             sessionDatabase.getAllRoom().toRooms()
+                    .filter { it.isNotEmpty() }
     override val topics: Flowable<List<Topic>> =
             sessionDatabase.getAllTopic().toTopics()
     override val sessions: Flowable<List<Session>> =


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
I added logic to filter the list to display a progress bar.
SessionsFragment has [logic](https://github.com/DroidKaigi/conference-app-2018/blob/master/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt#L45-L60) to display a progress bar while loading, but this does not work.
When there is no data locally ,` SessionDatabase.getAllRoom` returns an empty list, `onNext` of `SessionsViewModel.rooms` is called before getting data from the API, So, `isLoading` of` SessionsViewModel` is changed to false and the progress bar is gone before writing the fetched data to the database.
So, as a countermeasure, I added a code to filter the empty room


データ読み込みに時にプログレスバーを表示するために、空のroomsをフィルタリングするコードを追加しました。
SessionsFragmentにはロード中にプログレスバーを表示する[ロジック](https://github.com/DroidKaigi/conference-app-2018/blob/master/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt#L45-L60)がありますが、これは機能しません。
ローカルにデータがない場合でも、 `SessionDatabase.getAllRoom`が空のリストを返すため、APIからデータを取得する前に` SessionsViewModel.rooms`のOnNextが呼び出されます。
これにより、取得したデータをデータベースに書き込む前に、`SessionsViewModel`の` isLoading`がfalseに変更されプログレスバーは表示されなくなります。
なので、その対策として空のroomsをフィルタリングするコードを追加しました

## Links
-　None

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/12133543/35012495-457d65b4-fb4d-11e7-96fc-b44c3620e0ab.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/12133543/35012401-009746ea-fb4d-11e7-9b78-86bc6d3afcf7.gif" width="300" />
