### PR TITLE
fix feed item animation

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/FeedFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/FeedFragment.kt
@@ -66,14 +66,17 @@ class FeedFragment : Fragment(), Injectable {
                 is Result.Success -> {
                     val posts = result.data
                     val inflater = TransitionInflater.from(context)
-                    val expandTransition = inflater.inflateTransition(R.transition.expand_toggle)
+                    val expandTransition = inflater.inflateTransition(R.transition.feed_item_expand)
+                    val collapseTransition =
+                            inflater.inflateTransition(R.transition.feed_item_collapse)
                     postsSection.update(posts
                             .map {
                                 FeedItem(
                                         it,
                                         feedItemCollapsed,
                                         feedItemExpanded,
-                                        expandTransition
+                                        expandTransition,
+                                        collapseTransition
                                 )
                             })
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
@@ -11,7 +11,6 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ItemFeedBinding
 import io.github.droidkaigi.confsched2018.model.Post
 
-
 data class FeedItem(
         val post: Post,
         private val feedItemCollapsed: ConstraintSet,
@@ -37,8 +36,7 @@ data class FeedItem(
                     parent.setOnTouchListener(null)
                 }
             })
-            TransitionManager
-                    .beginDelayedTransition(parent, transition)
+            TransitionManager.beginDelayedTransition(parent, transition)
             expanded = !expanded
             if (!expanded) {
                 feedItemCollapsed.applyTo(viewBinding.feedItemConstraintLayout)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
@@ -26,7 +26,6 @@ data class FeedItem(
     override fun bind(viewBinding: ItemFeedBinding, position: Int) {
         viewBinding.post = post
         viewBinding.root.setOnClickListener {
-            // FIXME: Animation!!
             val parent = viewBinding.root.parent as RecyclerView
             parent.setOnTouchListener(touchIgnorer)
             val transition = (if (expanded) collapseTransition else expandTransition).clone()

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
@@ -2,29 +2,44 @@ package io.github.droidkaigi.confsched2018.presentation.feed.item
 
 import android.support.constraint.ConstraintSet
 import android.support.transition.Transition
+import android.support.transition.TransitionListenerAdapter
 import android.support.transition.TransitionManager
+import android.support.v7.widget.RecyclerView
+import android.view.View
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ItemFeedBinding
 import io.github.droidkaigi.confsched2018.model.Post
+
 
 data class FeedItem(
         val post: Post,
         private val feedItemCollapsed: ConstraintSet,
         private val feedItemExpanded: ConstraintSet,
         private val expandTransition: Transition,
+        private val collapseTransition: Transition,
         private var expanded: Boolean = false
 ) : BindableItem<ItemFeedBinding>(
         post.hashCode().toLong()
 ) {
+    private val touchIgnorer = View.OnTouchListener { _, _ -> true }
 
     override fun bind(viewBinding: ItemFeedBinding, position: Int) {
         viewBinding.post = post
         viewBinding.root.setOnClickListener {
-            expanded = !expanded
             // FIXME: Animation!!
+            val parent = viewBinding.root.parent as RecyclerView
+            parent.setOnTouchListener(touchIgnorer)
+            val transition = (if (expanded) collapseTransition else expandTransition).clone()
+
+            transition.addListener(object : TransitionListenerAdapter() {
+                override fun onTransitionEnd(transition: Transition) {
+                    parent.setOnTouchListener(null)
+                }
+            })
             TransitionManager
-                    .beginDelayedTransition(viewBinding.feedItemConstraintLayout, expandTransition)
+                    .beginDelayedTransition(parent, transition)
+            expanded = !expanded
             if (!expanded) {
                 feedItemCollapsed.applyTo(viewBinding.feedItemConstraintLayout)
             } else {

--- a/app/src/main/res/transition/feed_item_collapse.xml
+++ b/app/src/main/res/transition/feed_item_collapse.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  Copyright (c) 2017 Google Inc.
+
+  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+  in compliance with the License. You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under the License
+  is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+  or implied. See the License for the specific language governing permissions and limitations under
+  the License.
+  -->
+
+<transitionSet xmlns:android="http://schemas.android.com/apk/res/android"
+    android:transitionOrdering="together"
+    >
+
+    <changeBounds android:duration="250">
+        <targets>
+            <target android:targetId="@id/feed_item_constraint_layout" />
+        </targets>
+    </changeBounds>
+
+
+    <transition class="io.github.droidkaigi.confsched2018.presentation.common.transition.Rotate">
+        <targets>
+            <target android:targetId="@id/expand_icon" />
+        </targets>
+    </transition>
+    <changeBounds
+        android:duration="170"
+        android:startDelay="30"
+        >
+        <targets>
+            <target android:targetId="@id/content" />
+        </targets>
+        <arcMotion />
+    </changeBounds>
+
+    <changeBounds />
+
+    <fade
+        android:duration="50"
+        android:startDelay="200"
+        />
+
+</transitionSet>

--- a/app/src/main/res/transition/feed_item_expand.xml
+++ b/app/src/main/res/transition/feed_item_expand.xml
@@ -12,23 +12,27 @@
   the License.
   -->
 
-<transitionSet xmlns:android="http://schemas.android.com/apk/res/android">
+<transitionSet xmlns:android="http://schemas.android.com/apk/res/android"
+    android:transitionOrdering="together"
+    >
 
+    <changeBounds android:duration="50">
+        <targets>
+            <target android:targetId="@id/feed_item_constraint_layout" />
+        </targets>
+    </changeBounds>
     <transition class="io.github.droidkaigi.confsched2018.presentation.common.transition.Rotate">
         <targets>
             <target android:targetId="@id/expand_icon" />
         </targets>
     </transition>
-    <changeBounds
-        android:duration="170"
-        android:startDelay="30"
-        >
+
+    <changeBounds>
         <targets>
             <target android:targetId="@id/content" />
         </targets>
         <arcMotion />
     </changeBounds>
 
-    <changeBounds />
 
 </transitionSet>


### PR DESCRIPTION
## Issue
- close #245 

## Overview (Required)
- This makes feed screen title don't overlap when collapse

## Links
- 

## Screenshot
I added dummy data because feed api  returns empty list.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/2162201/35043056-79dc664e-fbce-11e7-90e9-d65e7fa72d1b.gif" width="300"/> | <img src="https://user-images.githubusercontent.com/2162201/35043111-a4b855e4-fbce-11e7-8286-b5c46c0d2c60.gif" width="300" />
