### PR TITLE
disable drawer icon rotation

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -42,7 +42,7 @@ class DrawerMenu @Inject constructor(
                 drawerLayout.addDrawerListener(it)
             }.apply {
                 isDrawerIndicatorEnabled = true
-                isDrawerSlideAnimationEnabled = true
+                isDrawerSlideAnimationEnabled = false
                 syncState()
             }
         }


### PR DESCRIPTION
## Issue
- None

## Overview (Required)
- Many apps made by Google don't rotate Drawer icon

## Links
- https://developer.android.com/reference/android/support/v7/app/ActionBarDrawerToggle.html#setDrawerSlideAnimationEnabled(boolean)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/445561/35045433-2c02709a-fbd7-11e7-94c6-2bd111ebfd1a.png" width="300" /> | <img src="https://user-images.githubusercontent.com/445561/35045488-4ca0adf8-fbd7-11e7-8155-ae37cf612ccc.png" width="300" />
