### PR TITLE
Add android lint to danger.

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -5,3 +5,9 @@ github.dismiss_out_of_range_messages
 checkstyle_format.base_path = Dir.pwd
 
 checkstyle_format.report "app/build/reports/ktlint/ktlint-#{ENV['APP_BUILD_TYPE'].downcase}.xml"
+
+# AndroidLint
+android_lint.report_file = "app/build/reports/lint-results-#{ENV['APP_BUILD_TYPE'].downcase}.xml"
+android_lint.skip_gradle_task = true
+android_lint.severity = "Error"
+android_lint.lint(inline_mode: true)

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ source "https://rubygems.org"
 
 gem "danger"
 gem "danger-checkstyle_format"
+gem "danger-android_lint"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,8 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    ansi (1.5.0)
+    ast (2.3.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
       cork
@@ -23,6 +25,9 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-android_lint (0.0.6)
+      danger-plugin-api (~> 1.0)
+      oga
     danger-checkstyle_format (0.1.1)
       danger-plugin-api (~> 1.0)
       ox (~> 2.0)
@@ -39,9 +44,15 @@ GEM
     no_proxy_fix (0.1.2)
     octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
+    oga (2.13)
+      ast
+      ruby-ll (~> 2.1)
     open4 (1.3.4)
     ox (2.8.2)
     public_suffix (3.0.1)
+    ruby-ll (2.1.2)
+      ansi
+      ast
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -54,6 +65,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger
+  danger-android_lint
   danger-checkstyle_format
 
 BUNDLED WITH


### PR DESCRIPTION
## Issue
- close #258 

## Overview (Required)
- Add `danger-android_lint` to comment from Android Lint.
- Do not comment `warnig`, but comment `error`.

## Links
- https://github.com/loadsmart/danger-android_lint

## Screenshot
None
