### PR TITLE
Add divider to search result

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -8,6 +8,7 @@ import android.support.annotation.StringRes
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentManager
 import android.support.v4.app.FragmentStatePagerAdapter
+import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SearchView
 import android.support.v7.widget.SimpleItemAnimator
 import android.view.LayoutInflater
@@ -32,6 +33,7 @@ import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessi
 import io.github.droidkaigi.confsched2018.util.ext.color
 import io.github.droidkaigi.confsched2018.util.ext.eachChildView
 import io.github.droidkaigi.confsched2018.util.ext.observe
+import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import io.github.droidkaigi.confsched2018.util.ext.toGone
 import io.github.droidkaigi.confsched2018.util.ext.toVisible
 import timber.log.Timber
@@ -123,6 +125,8 @@ class SearchFragment : Fragment(), Injectable {
         binding.sessionsRecycler.apply {
             adapter = groupAdapter
             (itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
+            setLinearDivider(R.drawable.shape_divider_vertical_6dp,
+                    layoutManager as LinearLayoutManager)
         }
     }
 

--- a/app/src/main/res/layout/item_search_speaker.xml
+++ b/app/src/main/res/layout/item_search_speaker.xml
@@ -15,8 +15,6 @@
     <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="4dp"
-        android:layout_marginTop="4dp"
         >
         <include
             android:id="@+id/search_content"


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Add divider to search result with DividerItemDecoration
- The divider of speaker became too big so I removed the margins

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/35054655-6e3bd140-fbf0-11e7-8ea4-b3e1c42aefc6.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/35054656-6e69ea12-fbf0-11e7-9850-3b2ea947c7d8.png" width="300" />
