### PR TITLE
SpeechSession model to immutable

### DIFF
--- a/model/src/main/java/io/github/droidkaigi/confsched2018/model/Session.kt
+++ b/model/src/main/java/io/github/droidkaigi/confsched2018/model/Session.kt
@@ -18,7 +18,7 @@ sealed class Session(
             val language: String,
             val topic: Topic,
             val level: Level,
-            var isFavorited: Boolean,
+            val isFavorited: Boolean,
             val speakers: List<Speaker>
     ) : Session(id, dayNumber, startTime, endTime)
 


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- SpeechSession model to immutable

## Links
- https://github.com/DroidKaigi/conference-app-2018/pull/266
- https://github.com/DroidKaigi/conference-app-2018/commit/764468b8343de1f00b1237b3dafb89feb7c73506#diff-a8739830a206ba578d7a1c70e83d9dad

By https://github.com/DroidKaigi/conference-app-2018/commit/764468b8343de1f00b1237b3dafb89feb7c73506#diff-a8739830a206ba578d7a1c70e83d9dad , `session#setIsFavorited(boolean)` is removed.
So, now we can make it completely immutable class.

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
