### PR TITLE
buildToolsVersion is not set (default used), and use latest version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ def versionPatch = 0
 
 android {
     compileSdkVersion versions.compileSdk
+    buildToolsVersion versions.buildTools
     dataBinding.enabled = true
 
     defaultConfig {

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     versions = [
             compileSdk      : 27,
-            buildTools      : "26.0.1",
+            buildTools      : "27.0.2",
             minSdk          : 19,
             targetSdk       : 27,
             gradleBuildTool : "3.0.1",


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- `buildTools      : "26.0.1"` is defined in `versions.gradle`, but it not used.
-  Use `buildTools` value and latest version `27.0.2`

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
