### PR TITLE
Replaced ci build url to CircleCI environment variable(CIRCLE_BUILD_URL)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -208,10 +208,10 @@ deploygate {
     apks {
         release {
             def hash = 'git rev-parse --short HEAD'.execute([], project.rootDir).in.text.trim()
-            message = "https://github.com/DroidKaigi/conference-app-2018/tree/${hash} https://circleci.com/gh/DroidKaigi/conference-app-2018/${System.getenv("CIRCLE_BUILD_NUM")}"
+            message = "https://github.com/DroidKaigi/conference-app-2018/tree/${hash} ${System.getenv("CIRCLE_BUILD_URL")}"
 
             distributionKey = "aed2445665e27de6571227992d66ea489b6bdb44"
-            releaseNote = "https://github.com/DroidKaigi/conference-app-2018/tree/${hash} https://circleci.com/gh/DroidKaigi/conference-app-2018/${System.getenv("CIRCLE_BUILD_NUM")}"
+            releaseNote = "https://github.com/DroidKaigi/conference-app-2018/tree/${hash} ${System.getenv("CIRCLE_BUILD_URL")}"
         }
     }
 }


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Replaced environment variable of CircleCI. I think it's clean.
※ I thought I want to replace `https://github.com/DroidKaigi/conference-app-2018/tree/${hash}` to `CIRCLE_REPOSITORY_URL`, but  [the format was changed in circleci2.0 (maybe bug)](https://discuss.circleci.com/t/circle-repository-url-changed-format-in-v2/15273) 😢 

## Links
- https://circleci.com/docs/2.0/env-vars/#build-details

## Screenshot
none
