### PR TITLE
Modify layout for favorite session item

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
@@ -20,9 +20,8 @@ import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
-import io.github.droidkaigi.confsched2018.presentation.sessions.item.DateSessionsSection
+import io.github.droidkaigi.confsched2018.presentation.sessions.item.FavoriteSessionItem
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.FavoriteSessionsSection
-import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
@@ -89,7 +88,7 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
         val groupAdapter = GroupAdapter<ViewHolder>().apply {
             add(sessionsSection)
             setOnItemClickListener({ item, _ ->
-                val sessionItem = item as? SpeechSessionItem ?: return@setOnItemClickListener
+                val sessionItem = item as? FavoriteSessionItem ?: return@setOnItemClickListener
                 navigationController.navigateToSessionDetailActivity(sessionItem.session)
             })
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
@@ -21,6 +21,7 @@ import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.DateSessionsSection
+import io.github.droidkaigi.confsched2018.presentation.sessions.item.FavoriteSessionsSection
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
@@ -37,7 +38,7 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
 
     private lateinit var binding: FragmentFavoriteSessionsBinding
 
-    private val sessionsSection = DateSessionsSection()
+    private val sessionsSection = FavoriteSessionsSection()
 
     @Inject lateinit var navigationController: NavigationController
     @Inject lateinit var sessionAlarm: SessionAlarm
@@ -72,7 +73,7 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
                     progressTimeLatch.loading = false
                     val sessions = result.data
                     sessionsSection.updateSessions(
-                            sessions, onFavoriteClickListener, simplify = true)
+                            sessions, onFavoriteClickListener)
                     binding.mysessionInactiveGroup.setVisible(sessions.isEmpty())
                     binding.sessionsRecycler.setVisible(sessions.isNotEmpty())
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionItem.kt
@@ -1,12 +1,9 @@
 package io.github.droidkaigi.confsched2018.presentation.sessions.item
 
-import android.support.v4.app.Fragment
 import com.xwray.groupie.databinding.BindableItem
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ItemFavoriteSessionBinding
-import io.github.droidkaigi.confsched2018.databinding.ItemSpeechSessionBinding
 import io.github.droidkaigi.confsched2018.model.Session
-import io.github.droidkaigi.confsched2018.util.lang
 
 data class FavoriteSessionItem(
         override val session: Session.SpeechSession,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionItem.kt
@@ -1,0 +1,26 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.item
+
+import android.support.v4.app.Fragment
+import com.xwray.groupie.databinding.BindableItem
+import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.databinding.ItemFavoriteSessionBinding
+import io.github.droidkaigi.confsched2018.databinding.ItemSpeechSessionBinding
+import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.util.lang
+
+data class FavoriteSessionItem(
+        override val session: Session.SpeechSession,
+        private val onFavoriteClickListener: (Session.SpeechSession) -> Unit
+) : BindableItem<ItemFavoriteSessionBinding>(
+        session.id.toLong()
+), SessionItem {
+
+    override fun bind(viewBinding: ItemFavoriteSessionBinding, position: Int) {
+        viewBinding.session = session
+        viewBinding.favorite.setOnClickListener {
+            onFavoriteClickListener(session)
+        }
+    }
+
+    override fun getLayout(): Int = R.layout.item_favorite_session
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
@@ -1,0 +1,60 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.item
+
+import android.support.v4.app.Fragment
+import com.xwray.groupie.Item
+import com.xwray.groupie.Section
+import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.model.toReadableDateString
+import io.github.droidkaigi.confsched2018.model.toReadableTimeString
+import java.util.SortedMap
+
+class FavoriteSessionsSection : Section() {
+    fun updateSessions(
+            sessions: List<Session>,
+            onFavoriteClickListener: (Session.SpeechSession) -> Unit
+    ) {
+        val sessionItems = sessions.map {
+            FavoriteSessionItem(it as Session.SpeechSession, onFavoriteClickListener) as SessionItem
+        }
+
+        val dateSpeechSessionItemsMap: SortedMap<ReadableDateTimePair, List<SessionItem>> =
+                sessionItems.groupBy {
+                    ReadableDateTimePair(it.session.startTime.toReadableDateString(),
+                            it.session.startTime.toReadableTimeString())
+                }.toSortedMap()
+
+        val dateSessions = arrayListOf<Item<*>>()
+        dateSpeechSessionItemsMap.keys.forEach { key ->
+            key ?: return@forEach
+            val list = dateSpeechSessionItemsMap[key]
+
+            val endTime = list!![0].session.endTime
+            val endDateTimePair = ReadableDateTimePair(endTime.toReadableDateString(),
+                    endTime.toReadableTimeString())
+            dateSessions.add(DateHeaderItem(key, endDateTimePair))
+            @Suppress("UNCHECKED_CAST")
+            dateSessions.addAll(list.toMutableList() as List<Item<*>>)
+        }
+        update(dateSessions)
+    }
+
+    fun getDateNumberOrNull(position: Int): Int? {
+        if (position < 0) return null
+
+        var item = getItemOrNull(position) ?: return null
+        item = item as? SpeechSessionItem ?: getItemOrNull(position + 1) ?: return null
+        return when (item) {
+            is SpeechSessionItem -> {
+                item.session.dayNumber
+            }
+            else -> null
+        }
+    }
+
+    private fun getItemOrNull(i: Int): Item<*>? {
+        if (itemCount <= i) {
+            return null
+        }
+        return getItem(i)
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2018.presentation.sessions.item
 
-import android.support.v4.app.Fragment
 import com.xwray.groupie.Item
 import com.xwray.groupie.Section
 import io.github.droidkaigi.confsched2018.model.Session

--- a/app/src/main/res/layout/item_favorite_session.xml
+++ b/app/src/main/res/layout/item_favorite_session.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+
+    <data>
+        <import type="android.view.View" />
+        <variable
+            name="session"
+            type="io.github.droidkaigi.confsched2018.model.Session.SpeechSession"
+            />
+    </data>
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clickable="true"
+        android:focusable="true"
+        android:foreground="?android:attr/selectableItemBackground"
+        android:stateListAnimator="@animator/card_state_list_anim"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:targetApi="lollipop"
+        >
+
+        <android.support.constraint.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            >
+
+            <TextView
+                android:id="@+id/day_number"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginTop="16dp"
+                android:text='@{"DAY"+session.dayNumber+" / "}'
+                android:textAppearance="@style/TextAppearance.App.Caption"
+                app:layout_constraintStart_toStartOf="@id/title"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="DAY1 / "
+                />
+
+            <TextView
+                android:id="@+id/period"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:textAppearance="@style/TextAppearance.App.Caption"
+                app:endDate="@{session.endTime}"
+                app:layout_constraintStart_toEndOf="@id/day_number"
+                app:layout_constraintTop_toTopOf="@id/day_number"
+                app:layout_goneMarginTop="16dp"
+                app:startDate="@{session.startTime}"
+                tools:text="10:30 - 11:00"
+                />
+
+            <TextView
+                android:id="@+id/room"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:maxLines="3"
+                android:textAppearance="@style/TextAppearance.App.Caption"
+                app:layout_constraintStart_toEndOf="@id/period"
+                app:layout_constraintTop_toTopOf="@+id/period"
+                app:prefix='@{" / "}'
+                app:roomName="@{session.room.name}"
+                tools:text=" / Room A"
+                />
+
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="10dp"
+                android:text="@{session.title}"
+                android:textAppearance="@style/TextAppearance.App.Title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/room"
+                app:layout_goneMarginTop="12dp"
+                tools:text="テストセッション"
+                />
+
+            <io.github.droidkaigi.confsched2018.presentation.common.view.SpeakersSummaryLayout
+                android:id="@+id/speaker_summary"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/favorite"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                app:layout_goneMarginTop="16dp"
+                app:speakers="@{session.speakers}"
+                />
+
+            <ImageView
+                android:id="@+id/favorite"
+                style="@style/FavoriteButton"
+                android:layout_marginEnd="8dp"
+                android:padding="16dp"
+                android:scaleType="center"
+                app:colorTint="@{session.isFavorited ? @color/accent : @color/sub_icon_color}"
+                app:layout_constraintBottom_toBottomOf="@id/speaker_summary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/speaker_summary"
+                app:srcCompat="@{session.isFavorited ? @drawable/ic_favorite_black_24dp : @drawable/ic_favorite_border_black_24dp}"
+                tools:src="@drawable/ic_favorite_black_24dp"
+                />
+
+        </android.support.constraint.ConstraintLayout>
+    </android.support.v7.widget.CardView>
+</layout>


### PR DESCRIPTION
## Issue

- close #333

## Overview (Required)

- Modify layout for favorite session item
  - I created some classes for favorite session 
  - And remove topic, level and description from layout

## Links

-

## Screenshot
Before | After
:--: | :--:
<img width="300" alt="2018-01-20 13 54 15" src="https://user-images.githubusercontent.com/966751/35180460-1d1a1a96-fdf4-11e7-9518-6c1a15662bfd.png"> | <img width="300" alt="2018-01-20 15 03 50" src="https://user-images.githubusercontent.com/966751/35180462-23eb0bd2-fdf4-11e7-9d64-ce6fcf188dfd.png">
