### PR TITLE
#329 Japanese translation for settings screen

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -59,6 +59,10 @@
 
     <!-- Settings -->
     <string name="settings_title_activity">設定</string>
+    <string name="settings_enable_local_time_title_preference">現在地の時間を使用する</string>
+    <string name="settings_enable_local_time_summary_preference">DroidKaigiの現地時間の代わりに現在地の時間を使用します。</string>
+    <string name="settings_enable_notification_title_preference">通知を受信する</string>
+    <string name="settings_enable_notification_summary_preference">このアプリで通知を受信するかどうかを選択できます。</string>
 
     <!-- Speaker -->
     <string name="speaker_title_activity_detail">スピーカー</string>


### PR DESCRIPTION
## Issue
- close #329 

## Overview (Required)
- I added Japanese translation texts for settings screen.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8677433/35182123-0dce2ab4-fe12-11e7-81ec-58b19f9c5263.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8677433/35182110-c8f922cc-fe11-11e7-90e3-575a3dc931fa.png" width="300" />
