### PR TITLE
Add transparent area to the left side of fast scroll thumb

### DIFF
--- a/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
+++ b/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle"
-    >
-    <corners android:radius="8dp" />
-    <solid android:color="@color/primary" />
-</shape>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="end">
+        <shape android:shape="rectangle">
+            <corners android:radius="8dp" />
+            <solid android:color="@color/primary" />
+            <size android:width="8dp" />
+        </shape>
+    </item>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@android:color/transparent" />
+            <size android:width="48dp" />
+        </shape>
+    </item>
+</layer-list>


### PR DESCRIPTION
## Overview (Required)
- This patch is a very small enhancement.  
Fast scroller in RecyclerView is added by #335. It's very cool.
But the thumb is not easy to touch. I think it's too small.
So I want to add transparent area to thumb's left side.
By this patch, users can use fast scroller easier.

## Links
- #335
- https://qiita.com/75py/items/b1d8505a70eb681d0fd9

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3153211/35184992-2e71a66e-fe40-11e7-940f-fa548b253e9e.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3153211/35184991-2e4b08ec-fe40-11e7-8667-5a5b321cde60.gif" width="300" />
