### PR TITLE
Add menu item to move to main screen into drawer

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -107,7 +107,10 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
         fun createIntent(context: Context): Intent = Intent(context, MainActivity::class.java)
 
         fun start(context: Context) {
-            context.startActivity(createIntent(context))
+            createIntent(context).let {
+                it.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+                context.startActivity(it)
+            }
         }
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -105,5 +105,9 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
 
     companion object {
         fun createIntent(context: Context): Intent = Intent(context, MainActivity::class.java)
+
+        fun start(context: Context) {
+            context.startActivity(createIntent(context))
+        }
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -91,6 +91,10 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
         replaceFragment(ContributorsFragment.newInstance())
     }
 
+    fun navigateToMainActivity() {
+        MainActivity.start(activity)
+    }
+
     fun navigateToContributorActivity() {
         ContributorsActivity.start(activity)
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -8,6 +8,7 @@ import android.support.v7.app.ActionBarDrawerToggle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.presentation.MainActivity
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.about.AboutThisAppActivity
 import io.github.droidkaigi.confsched2018.presentation.contributor.ContributorsActivity
@@ -82,6 +83,9 @@ class DrawerMenu @Inject constructor(
             val activityClass: KClass<*>,
             val navigate: NavigationController.() -> Unit
     ) {
+        HOME(R.id.nav_item_home, MainActivity::class, {
+            navigateToMainActivity()
+        }),
         ABOUT(R.id.nav_item_info, AboutThisAppActivity::class, {
             navigateToAboutThisAppActivity()
         }),

--- a/app/src/main/res/drawable/ic_home_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_home_black_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:alpha="0.58"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0"
+    >
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"
+        />
+</vector>

--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -6,6 +6,11 @@
         android:checkableBehavior="single"
         >
         <item
+            android:id="@+id/nav_item_home"
+            android:icon="@drawable/ic_home_black_24dp"
+            android:title="@string/nav_item_home"
+            />
+        <item
             android:id="@+id/nav_item_info"
             android:icon="@drawable/ic_information_black_24dp"
             android:title="@string/nav_item_info"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -3,6 +3,7 @@
     <string name="time_period">%1$s - %2$s</string>
 
     <!-- NavigationDrawer -->
+    <string name="nav_item_home">ホーム</string>
     <string name="nav_item_map">アクセス</string>
     <string name="nav_item_sponsor">スポンサー一覧</string>
     <string name="nav_item_contributor">@string/contributors</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="pref_key_enable_notification" translatable="false">pref_key_enable_notification</string>
 
     <!-- NavigationDrawer -->
+    <string name="nav_item_home">Home</string>
     <string name="nav_item_map">Map</string>
     <string name="nav_item_sponsor">Sponsor</string>
     <string name="nav_item_info">About this app</string>


### PR DESCRIPTION
## Issue
No issue.
Just a suggestion.

## Overview (Required)
Add menu item for moving main screen into drawer since sometimes I'd like to move the screen directly from another one.

If I move like `main -> about -> contributors` , we have to tap back-button 2 times to go back to main screen.
This make me feel inconvenience a bit.

vector asset was created by AS feature ([New] > [Vector Asset]).
https://developer.android.com/studio/write/vector-asset-studio.html#running

## Links
No.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3589344/35186205-d49510b8-fe53-11e7-9691-ac8a84155312.png" width="200" /> | <img src="https://user-images.githubusercontent.com/3589344/35186209-e25e6104-fe53-11e7-8fb9-3c3881018833.png" width="200" /><img src="https://user-images.githubusercontent.com/3589344/35186217-fd36c6a6-fe53-11e7-8a6b-ab8142e0fc87.png" width=200 />
