### PR TITLE
Fix the color of icon and text in the navigation drawer for accessibility

### DIFF
--- a/app/src/main/res/layout/activity_about_this_app.xml
+++ b/app/src/main/res/layout/activity_about_this_app.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_contributor.xml
+++ b/app/src/main/res/layout/activity_contributor.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -64,6 +64,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_session_detail.xml
+++ b/app/src/main/res/layout/activity_session_detail.xml
@@ -41,6 +41,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_speaker_detail.xml
+++ b/app/src/main/res/layout/activity_speaker_detail.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_sponsors.xml
+++ b/app/src/main/res/layout/activity_sponsors.xml
@@ -44,6 +44,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_topic_detail.xml
+++ b/app/src/main/res/layout/activity_topic_detail.xml
@@ -137,6 +137,8 @@
             android:id="@+id/drawer"
             style="@style/DrawerNavigation"
             app:headerLayout="@layout/drawer_header"
+            app:itemIconTint="@color/drawer_item_icon_tint"
+            app:itemTextColor="@color/drawer_item_text_color"
             app:menu="@menu/drawer"
             />
     </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -27,4 +27,7 @@
 
     <color name="item_header_background">#f5f5f5</color>
 
+    <color name="drawer_item_icon_tint">#666666</color>
+    <color name="drawer_item_text_color">#222222</color>
+
 </resources>


### PR DESCRIPTION
## Issue
- close #360

## Overview (Required)
- Add the colors of icon and text in navigation drawer to colors.xml
- Set the colors of icon and text in navigation drawer to layouts

## Links
- [android - Change the color of a checked menu item in a navigation drawer - Stack Overflow](https://stackoverflow.com/questions/30886453/change-the-color-of-a-checked-menu-item-in-a-navigation-drawer)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8059722/35187172-bf2ed916-fe62-11e7-9d39-76111504b3ce.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8059722/35187176-cc969b0c-fe62-11e7-9c2f-15c4a7b496d9.png" width="300" />

