### PR TITLE
Change to show Day Number in SessionsFragment screen.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -73,7 +73,7 @@ class AllSessionsFragment : Fragment(), Injectable {
             when (result) {
                 is Result.Success -> {
                     val sessions = result.data
-                    sessionsSection.updateSessions(sessions, onFavoriteClickListener)
+                    sessionsSection.updateSessions(sessions, onFavoriteClickListener, true)
 
                     sessionsViewModel.onSuccessFetchSessions()
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -81,7 +81,7 @@ class RoomSessionsFragment : Fragment(), Injectable {
             when (result) {
                 is Result.Success -> {
                     val sessions = result.data
-                    sessionsSection.updateSessions(sessions, onFavoriteClickListener)
+                    sessionsSection.updateSessions(sessions, onFavoriteClickListener, true)
 
                     sessionsViewModel.onSuccessFetchSessions()
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
@@ -10,18 +10,18 @@ class DateSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session>,
             onFavoriteClickListener: (Session.SpeechSession) -> Unit,
-            simplify: Boolean = false
+            isShowDayNumber: Boolean = false
     ) {
         val sessionItems = sessions.map {
             when (it) {
                 is Session.SpeechSession -> {
                     @Suppress("USELESS_CAST")
                     SpeechSessionItem(
-                            it, onFavoriteClickListener, simplify) as SessionItem
+                            it, onFavoriteClickListener, isShowDayNumber) as SessionItem
                 }
                 is Session.SpecialSession -> {
                     @Suppress("USELESS_CAST")
-                    SpecialSessionItem(it) as SessionItem
+                    SpecialSessionItem(it, isShowDayNumber) as SessionItem
                 }
             }
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
@@ -10,7 +10,7 @@ class DateSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session>,
             onFavoriteClickListener: (Session.SpeechSession) -> Unit,
-            simplify: Boolean = false
+            isShowDayNumber: Boolean = false
     ) {
         val sessionItems = sessions.map {
             when (it) {
@@ -19,14 +19,14 @@ class DateSessionsSection : Section() {
                     SpeechSessionItem(
                             session = it,
                             onFavoriteClickListener = onFavoriteClickListener,
-                            isShowDayNumber = simplify
+                            isShowDayNumber = isShowDayNumber
                     ) as SessionItem
                 }
                 is Session.SpecialSession -> {
                     @Suppress("USELESS_CAST")
                     SpecialSessionItem(
                             session = it,
-                            isShowDayNumber = simplify
+                            isShowDayNumber = isShowDayNumber
                     ) as SessionItem
                 }
             }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
@@ -10,18 +10,24 @@ class DateSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session>,
             onFavoriteClickListener: (Session.SpeechSession) -> Unit,
-            isShowDayNumber: Boolean = false
+            simplify: Boolean = false
     ) {
         val sessionItems = sessions.map {
             when (it) {
                 is Session.SpeechSession -> {
                     @Suppress("USELESS_CAST")
                     SpeechSessionItem(
-                            it, onFavoriteClickListener, isShowDayNumber) as SessionItem
+                            session = it,
+                            onFavoriteClickListener = onFavoriteClickListener,
+                            isShowDayNumber = simplify
+                    ) as SessionItem
                 }
                 is Session.SpecialSession -> {
                     @Suppress("USELESS_CAST")
-                    SpecialSessionItem(it, isShowDayNumber) as SessionItem
+                    SpecialSessionItem(
+                            session = it,
+                            isShowDayNumber = simplify
+                    ) as SessionItem
                 }
             }
         }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SimpleSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SimpleSessionsSection.kt
@@ -15,15 +15,17 @@ class SimpleSessionsSection : Section() {
                 is Session.SpeechSession -> {
                     @Suppress("USELESS_CAST")
                     SpeechSessionItem(
-                            it,
-                            onFavoriteClickListener,
-                            true,
-                            searchQuery
+                            session = it,
+                            onFavoriteClickListener = onFavoriteClickListener,
+                            isShowDayNumber = true,
+                            searchQuery = searchQuery
                     ) as Item<*>
                 }
                 is Session.SpecialSession -> {
                     @Suppress("USELESS_CAST")
-                    SpecialSessionItem(it) as Item<*>
+                    SpecialSessionItem(
+                            session = it
+                    ) as Item<*>
                 }
             }
         }


### PR DESCRIPTION
## Issue
- There is no Issue.

## Overview (Required)
It is a suggestion for improvement on SessionsFragment screen.
Change to show Day Number.

I think that it is unfriendly not to display Day Number on this screen.
In other screens, Day Number is already displayed.

## Links
-

## Screenshot
Before | After
:--: | :--:
![show_day_before](https://user-images.githubusercontent.com/29206446/35189187-b183307a-fe88-11e7-8d06-6fb52a05705d.png) | ![show_day_after](https://user-images.githubusercontent.com/29206446/35189186-b1576026-fe88-11e7-9aaf-95463a513541.png)
