### PR TITLE
fix session speaker's name hidden problem, add bottom margin

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -49,6 +49,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:fitsSystemWindows="true"
+                    android:layout_marginBottom="8dp"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed"
                     app:titleEnabled="false"
                     >


### PR DESCRIPTION
## Issue
- close #375

## Overview (Required)
- It is suggestion to add bottom margin to appbar
- It resolve long speaker name hidden problem

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3090219/35190231-f0f6c278-fe9f-11e7-9dbc-eb8871cef4b0.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3090219/35190053-f53123be-fe9b-11e7-9cae-57488e916f75.png" width="300" />
