### PR TITLE
Fix fast scroll thumb for API 22 or lower

### DIFF
--- a/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
+++ b/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:gravity="end">
+    <item android:left="40dp">
         <shape android:shape="rectangle">
             <corners android:radius="8dp" />
             <solid android:color="@color/primary" />


### PR DESCRIPTION
## Overview (Required)
- Fix the fast scroll thumb xml
Sorry but my patch #365 didn't work perfectly in API 22 or lower.
In API 22, the thumb's width was expanded to 48dp.
I used 'gravity' but it didn't work, so I change it to 'paddingLeft'.
　
I tested it in emulators that API 19, 21, 22, 23, 24, 25, 26.

## Screenshot(API 21)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3153211/35190631-64593666-fea9-11e7-8532-8c038eca5d32.png" width="300" /> | <img src="https://user-images.githubusercontent.com/3153211/35190630-642e6ef4-fea9-11e7-8bb4-724e471e1bbd.png" width="300" />

