### PR TITLE
Extract the attributes in FrameLayout to styles.xml

### DIFF
--- a/app/src/main/res/layout/activity_about_this_app.xml
+++ b/app/src/main/res/layout/activity_about_this_app.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_about_this_app.xml
+++ b/app/src/main/res/layout/activity_about_this_app.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.about.AboutThisAppActivity"
     >
@@ -25,12 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_contributor.xml
+++ b/app/src/main/res/layout/activity_contributor.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_contributor.xml
+++ b/app/src/main/res/layout/activity_contributor.xml
@@ -25,12 +25,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_contributor.xml
+++ b/app/src/main/res/layout/activity_contributor.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.contributor.ContributorsActivity"
     >

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,12 +31,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
 
             <android.support.design.widget.BottomNavigationView

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -31,7 +31,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
 
             <android.support.design.widget.BottomNavigationView

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -25,12 +25,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.map.MapActivity"
     >

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -25,12 +25,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.settings.SettingsActivity"
     >

--- a/app/src/main/res/layout/activity_speaker_detail.xml
+++ b/app/src/main/res/layout/activity_speaker_detail.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_speaker_detail.xml
+++ b/app/src/main/res/layout/activity_speaker_detail.xml
@@ -25,12 +25,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_speaker_detail.xml
+++ b/app/src/main/res/layout/activity_speaker_detail.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.speaker.SpeakerDetailActivity"
     >

--- a/app/src/main/res/layout/activity_sponsors.xml
+++ b/app/src/main/res/layout/activity_sponsors.xml
@@ -24,7 +24,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                style="@style/FrameLayout"
+                style="@style/ContentFrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_sponsors.xml
+++ b/app/src/main/res/layout/activity_sponsors.xml
@@ -25,12 +25,7 @@
 
             <FrameLayout
                 android:id="@+id/content"
-                android:layout_width="0dp"
-                android:layout_height="0dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                style="@style/FrameLayout"
                 />
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_sponsors.xml
+++ b/app/src/main/res/layout/activity_sponsors.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.sponsors.SponsorsActivity"
     >

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -63,7 +63,7 @@
         <item name="titleTextColor">@color/app_bar_text_color</item>
     </style>
 
-    <style name="FrameLayout">
+    <style name="ContentFrameLayout">
         <item name="android:layout_width">0dp</item>
         <item name="android:layout_height">0dp</item>
         <item name="layout_constraintBottom_toBottomOf">parent</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -62,4 +62,13 @@
         <item name="layout_constraintTop_toTopOf">parent</item>
         <item name="titleTextColor">@color/app_bar_text_color</item>
     </style>
+
+    <style name="FrameLayout">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">0dp</item>
+        <item name="layout_constraintBottom_toBottomOf">parent</item>
+        <item name="layout_constraintEnd_toEndOf">parent</item>
+        <item name="layout_constraintStart_toStartOf">parent</item>
+        <item name="layout_constraintTop_toBottomOf">@id/toolbar</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Extract attributes in FrameLayout to styles.xml
- Remove unused namespace declaration (`xmlns:app`)

## Links
- Similar PR: https://github.com/DroidKaigi/conference-app-2018/pull/382

## Screenshot
none
