### PR TITLE
Remove unused namespace declaration in the layout of Session Detail Screen

### DIFF
--- a/app/src/main/res/layout/activity_session_detail.xml
+++ b/app/src/main/res/layout/activity_session_detail.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".presentation.detail.SessionDetailActivity"
     >


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Remove unused namespace declaration in the layout of Session Detail Screen

## Links
- none

## Screenshot
none
