### PR TITLE
Support VectorDrawable in Kikat

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -2,6 +2,9 @@ package io.github.droidkaigi.confsched2018.presentation.common.binding
 
 import android.databinding.BindingAdapter
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.StateListDrawable
+import android.os.Build
 import android.support.v4.content.ContextCompat
 import android.text.Spannable
 import android.text.SpannableStringBuilder
@@ -72,4 +75,16 @@ fun TextView.setHighlightText(highlightText: String?) {
         )
     }
     text = stringBuilder
+}
+
+@BindingAdapter(value = ["vectorDrawableStart"])
+fun TextView.setVectorDrawableStart(drawable: Drawable) {
+    val vectorDrawable = drawable.takeIf {
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
+    } ?: StateListDrawable().apply {
+        addState(intArrayOf(0), drawable)
+    }
+
+    val drawables = compoundDrawables
+    setCompoundDrawablesWithIntrinsicBounds(vectorDrawable, drawables[1], drawables[2], drawables[3])
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -86,5 +86,10 @@ fun TextView.setVectorDrawableStart(drawable: Drawable) {
     }
 
     val drawables = compoundDrawables
-    setCompoundDrawablesWithIntrinsicBounds(vectorDrawable, drawables[1], drawables[2], drawables[3])
+    setCompoundDrawablesWithIntrinsicBounds(
+            vectorDrawable,
+            drawables[1],
+            drawables[2],
+            drawables[3]
+    )
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -82,7 +82,7 @@ fun TextView.setVectorDrawableStart(drawable: Drawable) {
     val vectorDrawable = drawable.takeIf {
         Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP
     } ?: StateListDrawable().apply {
-        addState(intArrayOf(0), drawable)
+        addState(intArrayOf(), drawable)
     }
 
     val drawables = compoundDrawables

--- a/app/src/main/res/layout/item_speech_session.xml
+++ b/app/src/main/res/layout/item_speech_session.xml
@@ -204,7 +204,6 @@
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:drawablePadding="4dp"
-                android:drawableStart="@drawable/ic_check_circle_black_24dp"
                 android:gravity="center_vertical"
                 android:text="@string/session_finished"
                 android:textColor="@android:color/black"
@@ -213,6 +212,8 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/divider_finished_session"
+                app:vectorDrawableStart="@{@drawable/ic_check_circle_black_24dp}"
+                tools:drawableStart="@drawable/ic_check_circle_black_24dp"
                 />
 
             <TextView


### PR DESCRIPTION
## Issue
- close #307

## Overview (Required)
- Support VectorDrawable in Kitkat
- I named `vectorDrawableStart` to separate from regular `drawbleStart`.
- Since `VectorDrawable` had no problem with `Lollipop` or higher version, it was delimited by "Build.VERSION.SDK_INT> = Build.VERSION_CODES.LOLLIPOP".
- Added `tools: drawableStart` for Design Preview.

## Links
-  https://qiita.com/konifar/items/bf581b8f23dea7b30f85#2-textviewのandroiddrawableleft