### PR TITLE
Fix "contributors" Japanese translation at About Screen

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,7 @@
     <string name="about_licenses_description">このアプリでは、多くの素晴らしいライブラリを使用させていただいています。 </string>
     <string name="about_sponsors_title">スポンサー</string>
     <string name="about_sponsors_description">DroidKaigiは多くのスポンサーによってサポートされています。</string>
-    <string name="about_contributors_title">コントリビュータ</string>
+    <string name="about_contributors_title">コントリビューター</string>
     <string name="about_contributors_description">App制作に携わった人たちです。</string>
     <string name="about_version_title">開発情報</string>
     <string name="about_version_description">%1$s</string>


### PR DESCRIPTION
## Overview (Required)
 - Tooooooooooo small fix :)
- Fix `contributors` Japanese translation at About Screen from `コントリビュータ` to `コントリビューター` , because all other `contributors` Japanese translation is `コントリビューター`


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1281509/35191506-a2eb9bb0-febf-11e7-8a61-4459dc5de0c0.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1281509/35191508-b0814842-febf-11e7-9e4f-2a3393699d61.png" width="300" />