### PR TITLE
Fix Firestore document create each time

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
@@ -109,8 +109,7 @@ class FavoriteFirestoreDatabase : FavoriteDatabase {
                     e.onError(task.exception!!)
                     return@addOnCompleteListener
                 }
-                if (!task.result.isEmpty) {
-                    // FIXME: I want to create document without setting value
+                if (task.result.isEmpty) {
                     favorites.add(mapOf("initialized" to true)).addOnCompleteListener {
                         if (DEBUG) Timber.d("Firestore:create document for listing")
                         e.onSuccess(currentUser)


### PR DESCRIPTION
## Overview (Required)
- Title says everything

first launch

```
D/FavoriteFirestoreDatabase$getCurrentUser: Firestore:Sign in Anonymously
D/FavoriteFirestoreDatabase$setupFavoritesDocument: Firestore:setupFavoritesDocument
D/FavoriteFirestoreDatabase$setupFavoritesDocument: Firestore:setupFavoritesDocument onComplete
D/FavoriteFirestoreDatabase$setupFavoritesDocument: Firestore:create document for listing
D/FavoriteFirestoreDatabase$getFavorites: Firestore:getFavorites
D/FavoriteFirestoreDatabase$getFavorites$1$eventListener: Firestore:getFavorites return empty
```

favorite

```
D/FavoriteFirestoreDatabase$getCurrentUser: Firestore:Get cached user
D/FavoriteFirestoreDatabase$favorite: Firestore:favorite get
D/FavoriteFirestoreDatabase$getFavorites$1$eventListener: Firestore:getFavorites onChange
D/FavoriteFirestoreDatabase$getFavorites$1$eventListener: Firestore:getFavorites onChange [16969]
D/FavoriteFirestoreDatabase$favorite$1$1$1$completeListener: Firestore:favorite write success
```

Second time launch

```
ser: Firestore:Get cached user
tesDocument: Firestore:setupFavoritesDocument
D/FavoriteFirestoreDatabase$setupFavoritesDocument: Firestore:setupFavoritesDocument onComplete
D/FavoriteFirestoreDatabase$setupFavoritesDocument: Firestore:document already exists
D/FavoriteFirestoreDatabase$getFavorites: Firestore:getFavorites
D/FavoriteFirestoreDatabase$getFavorites$1$eventListener: Firestore:getFavorites onChange
D/FavoriteFirestoreDatabase$getFavorites$1$eventListener: Firestore:getFavorites onChange [16969]
```