### PR TITLE
Stop using lineSpacing attribute before lollipop

### DIFF
--- a/app/src/main/res/values-v21/text_apperance.xml
+++ b/app/src/main/res/values-v21/text_apperance.xml
@@ -1,0 +1,54 @@
+<resources>
+
+    <style name="TextStyle" />
+
+    <style name="TextStyle.App" />
+
+    <style name="TextStyle.App.Title">
+        <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
+        <item name="android:lineSpacingMultiplier">1.25</item>
+        <!-- 1.25 (Title is 21sp and "should exist as single lines", so adjusted manually) -->
+    </style>
+
+
+    <style name="TextStyle.App.Subhead">
+        <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
+        <item name="android:lineSpacingMultiplier">1.76</item>
+        <!-- 1.76 ≒ 30 / 17 (Type 17sp, Leading 30dp) -->
+    </style>
+
+    <style name="TextStyle.App.Headline">
+        <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
+        <item name="android:lineSpacingMultiplier">1.42</item>
+        <!-- 1.42 ≒ 34 / 24  (Type 24sp, Leading 34dp) -->
+    </style>
+
+
+    <style name="TextStyle.App.Body2">
+        <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
+        <item name="android:lineSpacingMultiplier">1.86</item>
+        <!-- 1.86 ≒ 26 / 14  (Type 14sp, Leading 26dp) -->
+    </style>
+
+
+    <style name="TextStyle.App.Body1">
+        <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
+        <item name="android:lineSpacingMultiplier">1.64</item>
+        <!-- 1.64 ≒ 23 / 14  (Type 14sp, Leading 23dp) -->
+    </style>
+
+    <style name="TextStyle.App.Caption">
+        <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
+        <item name="android:lineSpacingMultiplier">1.69</item>
+        <!-- 1.69 (Title is 13sp and "should exist as single lines", so adjusted manually) -->
+    </style>
+
+    <!-- These lineSpacingMultiplier values are decided like below: -->
+    <!-- For Example, "Headline" of "Dense and tall scripts" has been designated "Type 24sp, Leading 34dp".
+    And, If we use this app with larger font setting, line spacing should be wide too.
+    So value was thought 1.42 (≒ 34dp ÷ 24sp on normal font setting) in the case.
+    On the other hand, "Title" has been designated 21sp and "should exist as single lines",
+    we don't have any designated leading value. But, It may become multi-line on this app,
+    so its value was decided based on Zeplin Scene and adjusted.  -->
+    <!-- see https://material.io/guidelines/style/typography.html#typography-line-height -->
+</resources>

--- a/app/src/main/res/values-v21/text_apperance.xml
+++ b/app/src/main/res/values-v21/text_apperance.xml
@@ -1,30 +1,31 @@
 <resources>
-    <style name="TextStyle.App.Title">
+
+    <style name="TextStyle.App.Title" parent="Platform.TextStyle.App.Title">
         <item name="android:lineSpacingMultiplier">1.25</item>
         <!-- 1.25 (Title is 21sp and "should exist as single lines", so adjusted manually) -->
     </style>
 
-    <style name="TextStyle.App.Subhead">
+    <style name="TextStyle.App.Subhead" parent="Platform.TextStyle.App.Subhead">
         <item name="android:lineSpacingMultiplier">1.76</item>
         <!-- 1.76 ≒ 30 / 17 (Type 17sp, Leading 30dp) -->
     </style>
 
-    <style name="TextStyle.App.Headline">
+    <style name="TextStyle.App.Headline" parent="Platform.TextStyle.App.Headline">
         <item name="android:lineSpacingMultiplier">1.42</item>
         <!-- 1.42 ≒ 34 / 24  (Type 24sp, Leading 34dp) -->
     </style>
 
-    <style name="TextStyle.App.Body2">
+    <style name="TextStyle.App.Body2" parent="Platform.TextStyle.App.Body2">
         <item name="android:lineSpacingMultiplier">1.86</item>
         <!-- 1.86 ≒ 26 / 14  (Type 14sp, Leading 26dp) -->
     </style>
 
-    <style name="TextStyle.App.Body1">
+    <style name="TextStyle.App.Body1" parent="Platform.TextStyle.App.Body1">
         <item name="android:lineSpacingMultiplier">1.64</item>
         <!-- 1.64 ≒ 23 / 14  (Type 14sp, Leading 23dp) -->
     </style>
 
-    <style name="TextStyle.App.Caption">
+    <style name="TextStyle.App.Caption" parent="Platform.TextStyle.App.Caption">
         <item name="android:lineSpacingMultiplier">1.69</item>
         <!-- 1.69 (Title is 13sp and "should exist as single lines", so adjusted manually) -->
     </style>

--- a/app/src/main/res/values-v21/text_apperance.xml
+++ b/app/src/main/res/values-v21/text_apperance.xml
@@ -1,44 +1,30 @@
 <resources>
-
-    <style name="TextStyle" />
-
-    <style name="TextStyle.App" />
-
     <style name="TextStyle.App.Title">
-        <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
         <item name="android:lineSpacingMultiplier">1.25</item>
         <!-- 1.25 (Title is 21sp and "should exist as single lines", so adjusted manually) -->
     </style>
 
-
     <style name="TextStyle.App.Subhead">
-        <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
         <item name="android:lineSpacingMultiplier">1.76</item>
         <!-- 1.76 ≒ 30 / 17 (Type 17sp, Leading 30dp) -->
     </style>
 
     <style name="TextStyle.App.Headline">
-        <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
         <item name="android:lineSpacingMultiplier">1.42</item>
         <!-- 1.42 ≒ 34 / 24  (Type 24sp, Leading 34dp) -->
     </style>
 
-
     <style name="TextStyle.App.Body2">
-        <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
         <item name="android:lineSpacingMultiplier">1.86</item>
         <!-- 1.86 ≒ 26 / 14  (Type 14sp, Leading 26dp) -->
     </style>
 
-
     <style name="TextStyle.App.Body1">
-        <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
         <item name="android:lineSpacingMultiplier">1.64</item>
         <!-- 1.64 ≒ 23 / 14  (Type 14sp, Leading 23dp) -->
     </style>
 
     <style name="TextStyle.App.Caption">
-        <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
         <item name="android:lineSpacingMultiplier">1.69</item>
         <!-- 1.69 (Title is 13sp and "should exist as single lines", so adjusted manually) -->
     </style>

--- a/app/src/main/res/values-v21/text_apperance.xml
+++ b/app/src/main/res/values-v21/text_apperance.xml
@@ -1,31 +1,31 @@
 <resources>
 
-    <style name="TextStyle.App.Title" parent="Platform.TextStyle.App.Title">
+    <style name="Platform.TextStyle.App.Title">
         <item name="android:lineSpacingMultiplier">1.25</item>
         <!-- 1.25 (Title is 21sp and "should exist as single lines", so adjusted manually) -->
     </style>
 
-    <style name="TextStyle.App.Subhead" parent="Platform.TextStyle.App.Subhead">
+    <style name="Platform.TextStyle.App.Subhead">
         <item name="android:lineSpacingMultiplier">1.76</item>
         <!-- 1.76 ≒ 30 / 17 (Type 17sp, Leading 30dp) -->
     </style>
 
-    <style name="TextStyle.App.Headline" parent="Platform.TextStyle.App.Headline">
+    <style name="Platform.TextStyle.App.Headline">
         <item name="android:lineSpacingMultiplier">1.42</item>
         <!-- 1.42 ≒ 34 / 24  (Type 24sp, Leading 34dp) -->
     </style>
 
-    <style name="TextStyle.App.Body2" parent="Platform.TextStyle.App.Body2">
+    <style name="Platform.TextStyle.App.Body2">
         <item name="android:lineSpacingMultiplier">1.86</item>
         <!-- 1.86 ≒ 26 / 14  (Type 14sp, Leading 26dp) -->
     </style>
 
-    <style name="TextStyle.App.Body1" parent="Platform.TextStyle.App.Body1">
+    <style name="Platform.TextStyle.App.Body1">
         <item name="android:lineSpacingMultiplier">1.64</item>
         <!-- 1.64 ≒ 23 / 14  (Type 14sp, Leading 23dp) -->
     </style>
 
-    <style name="TextStyle.App.Caption" parent="Platform.TextStyle.App.Caption">
+    <style name="Platform.TextStyle.App.Caption">
         <item name="android:lineSpacingMultiplier">1.69</item>
         <!-- 1.69 (Title is 13sp and "should exist as single lines", so adjusted manually) -->
     </style>

--- a/app/src/main/res/values/text_apperance.xml
+++ b/app/src/main/res/values/text_apperance.xml
@@ -37,50 +37,29 @@
 
     <style name="TextStyle.App.Title">
         <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
-        <item name="android:lineSpacingMultiplier">1.25</item>
-        <!-- 1.25 (Title is 21sp and "should exist as single lines", so adjusted manually) -->
     </style>
 
 
     <style name="TextStyle.App.Subhead">
         <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
-        <item name="android:lineSpacingMultiplier">1.76</item>
-        <!-- 1.76 ≒ 30 / 17 (Type 17sp, Leading 30dp) -->
     </style>
 
     <style name="TextStyle.App.Headline">
         <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
-        <item name="android:lineSpacingMultiplier">1.42</item>
-        <!-- 1.42 ≒ 34 / 24  (Type 24sp, Leading 34dp) -->
     </style>
 
 
     <style name="TextStyle.App.Body2">
         <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
-        <item name="android:lineSpacingMultiplier">1.86</item>
-        <!-- 1.86 ≒ 26 / 14  (Type 14sp, Leading 26dp) -->
     </style>
 
 
     <style name="TextStyle.App.Body1">
         <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
-        <item name="android:lineSpacingMultiplier">1.64</item>
-        <!-- 1.64 ≒ 23 / 14  (Type 14sp, Leading 23dp) -->
     </style>
 
     <style name="TextStyle.App.Caption">
         <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
-        <item name="android:lineSpacingMultiplier">1.69</item>
-        <!-- 1.69 (Title is 13sp and "should exist as single lines", so adjusted manually) -->
     </style>
-
-    <!-- These lineSpacingMultiplier values are decided like below: -->
-    <!-- For Example, "Headline" of "Dense and tall scripts" has been designated "Type 24sp, Leading 34dp".
-    And, If we use this app with larger font setting, line spacing should be wide too.
-    So value was thought 1.42 (≒ 34dp ÷ 24sp on normal font setting) in the case.
-    On the other hand, "Title" has been designated 21sp and "should exist as single lines",
-    we don't have any designated leading value. But, It may become multi-line on this app,
-    so its value was decided based on Zeplin Scene and adjusted.  -->
-    <!-- see https://material.io/guidelines/style/typography.html#typography-line-height -->
 
 </resources>

--- a/app/src/main/res/values/text_apperance.xml
+++ b/app/src/main/res/values/text_apperance.xml
@@ -39,7 +39,6 @@
         <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
     </style>
 
-
     <style name="TextStyle.App.Subhead">
         <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
     </style>
@@ -48,11 +47,9 @@
         <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
     </style>
 
-
     <style name="TextStyle.App.Body2">
         <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
     </style>
-
 
     <style name="TextStyle.App.Body1">
         <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>

--- a/app/src/main/res/values/text_apperance.xml
+++ b/app/src/main/res/values/text_apperance.xml
@@ -31,32 +31,50 @@
         <item name="android:fontFamily">@font/notosans_regular</item>
     </style>
 
-    <style name="TextStyle" />
+    <style name="Platform" />
 
-    <style name="TextStyle.App" />
+    <style name="Platform.TextStyle" />
 
-    <style name="TextStyle.App.Title">
+    <style name="Platform.TextStyle.App" />
+
+    <style name="Platform.TextStyle.App.Title">
         <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
     </style>
 
-    <style name="TextStyle.App.Subhead">
+    <style name="Platform.TextStyle.App.Subhead">
         <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
     </style>
 
-    <style name="TextStyle.App.Headline">
+    <style name="Platform.TextStyle.App.Headline">
         <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
     </style>
 
-    <style name="TextStyle.App.Body2">
+    <style name="Platform.TextStyle.App.Body2">
         <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
     </style>
 
-    <style name="TextStyle.App.Body1">
+    <style name="Platform.TextStyle.App.Body1">
         <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
     </style>
 
-    <style name="TextStyle.App.Caption">
+    <style name="Platform.TextStyle.App.Caption">
         <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
     </style>
+
+    <style name="TextStyle" parent="Platform.TextStyle"/>
+
+    <style name="TextStyle.App" parent="Platform.TextStyle.App"/>
+
+    <style name="TextStyle.App.Title" parent="Platform.TextStyle.App.Title"/>
+
+    <style name="TextStyle.App.Subhead" parent="Platform.TextStyle.App.Subhead"/>
+
+    <style name="TextStyle.App.Headline" parent="Platform.TextStyle.App.Headline"/>
+
+    <style name="TextStyle.App.Body2" parent="Platform.TextStyle.App.Body2"/>
+
+    <style name="TextStyle.App.Body1" parent="Platform.TextStyle.App.Body1"/>
+
+    <style name="TextStyle.App.Caption" parent="Platform.TextStyle.App.Caption"/>
 
 </resources>

--- a/app/src/main/res/values/text_apperance.xml
+++ b/app/src/main/res/values/text_apperance.xml
@@ -32,49 +32,41 @@
     </style>
 
     <style name="Platform" />
-
     <style name="Platform.TextStyle" />
-
     <style name="Platform.TextStyle.App" />
-
-    <style name="Platform.TextStyle.App.Title">
-        <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
-    </style>
-
-    <style name="Platform.TextStyle.App.Subhead">
-        <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
-    </style>
-
-    <style name="Platform.TextStyle.App.Headline">
-        <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
-    </style>
-
-    <style name="Platform.TextStyle.App.Body2">
-        <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
-    </style>
-
-    <style name="Platform.TextStyle.App.Body1">
-        <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
-    </style>
-
-    <style name="Platform.TextStyle.App.Caption">
-        <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
-    </style>
+    <style name="Platform.TextStyle.App.Title"/>
+    <style name="Platform.TextStyle.App.Subhead"/>
+    <style name="Platform.TextStyle.App.Headline"/>
+    <style name="Platform.TextStyle.App.Body2"/>
+    <style name="Platform.TextStyle.App.Body1"/>
+    <style name="Platform.TextStyle.App.Caption"/>
 
     <style name="TextStyle" parent="Platform.TextStyle"/>
 
     <style name="TextStyle.App" parent="Platform.TextStyle.App"/>
 
-    <style name="TextStyle.App.Title" parent="Platform.TextStyle.App.Title"/>
+    <style name="TextStyle.App.Title" parent="Platform.TextStyle.App.Title">
+        <item name="android:textAppearance">@style/TextAppearance.App.Title</item>
+    </style>
 
-    <style name="TextStyle.App.Subhead" parent="Platform.TextStyle.App.Subhead"/>
+    <style name="TextStyle.App.Subhead" parent="Platform.TextStyle.App.Subhead">
+        <item name="android:textAppearance">@style/TextAppearance.App.Subhead</item>
+    </style>
 
-    <style name="TextStyle.App.Headline" parent="Platform.TextStyle.App.Headline"/>
+    <style name="TextStyle.App.Headline" parent="Platform.TextStyle.App.Headline">
+        <item name="android:textAppearance">@style/TextAppearance.App.Headline</item>
+    </style>
 
-    <style name="TextStyle.App.Body2" parent="Platform.TextStyle.App.Body2"/>
+    <style name="TextStyle.App.Body2" parent="Platform.TextStyle.App.Body2">
+        <item name="android:textAppearance">@style/TextAppearance.App.Body2</item>
+    </style>
 
-    <style name="TextStyle.App.Body1" parent="Platform.TextStyle.App.Body1"/>
+    <style name="TextStyle.App.Body1" parent="Platform.TextStyle.App.Body1">
+        <item name="android:textAppearance">@style/TextAppearance.App.Body1</item>
+    </style>
 
-    <style name="TextStyle.App.Caption" parent="Platform.TextStyle.App.Caption"/>
+    <style name="TextStyle.App.Caption" parent="Platform.TextStyle.App.Caption">
+        <item name="android:textAppearance">@style/TextAppearance.App.Caption</item>
+    </style>
 
 </resources>


### PR DESCRIPTION
## Issue
- close #287, close #288

## Overview (Required)
- Fix the TextView layout problem on api level 19 or lower. TextView that using lineSpacing attribute has unnecessary spacing at bottom on api level 19 (It seems like a platform bug).
- Thanks @takahirom and @konifar for giving me good advices.

## Screenshot(Session Feed Screen / api level 19, Asus Zenfone 5)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13427854/35193572-eff6a288-fee7-11e7-8499-43b695bdaa47.jpg" width="300" /> | <img src="https://user-images.githubusercontent.com/13427854/35193574-f284f31a-fee7-11e7-8c70-7625104c9e3e.jpg" />

## Screenshot(Session Detail Screen / api level 19, Asus Zenfone 5)
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13427854/35193599-482fd708-fee8-11e7-828d-ee34faa9e723.jpg" /> | <img src="https://user-images.githubusercontent.com/13427854/35193600-4b6c7dc2-fee8-11e7-8783-8d7bf86a2d1f.jpg" />

## Screenshot(Session Feed Screen / api level 23, Nexus 5X) ※Nothing changes
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13427854/35193668-613dcbdc-fee9-11e7-958f-102f2aefa047.jpg" /> | <img src="https://user-images.githubusercontent.com/13427854/35193669-64f49f44-fee9-11e7-80aa-31c916d2599c.jpg" />

## Screenshot(Session Detail Screen / api level 23, Nexus 5X) ※Nothing changes
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/13427854/35193677-92f0425e-fee9-11e7-91f4-148e92f84a80.jpg" /> | <img src="https://user-images.githubusercontent.com/13427854/35193678-9614e610-fee9-11e7-8a76-b41fc82c57c9.jpg" />