### PR TITLE
ripple effect for SocialMediaButton

### DIFF
--- a/app/src/main/res/drawable-v21/bg_social_media_button.xml
+++ b/app/src/main/res/drawable-v21/bg_social_media_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/social_media_button_ripple"
+    >
+    <item android:drawable="@drawable/shape_round_corner_48dp" />
+</ripple>

--- a/app/src/main/res/drawable/bg_social_media_button.xml
+++ b/app/src/main/res/drawable/bg_social_media_button.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/shape_round_corner_48dp" />
+</selector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,4 +30,5 @@
     <color name="drawer_item_icon_tint">#666666</color>
     <color name="drawer_item_text_color">#222222</color>
 
+    <color name="social_media_button_ripple">#40000000</color>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -79,7 +79,7 @@
     </style>
 
     <style name="SocialMediaButton">
-        <item name="android:background">@drawable/shape_round_corner_48dp</item>
+        <item name="android:background">@drawable/bg_social_media_button</item>
         <item name="android:elevation" tools:targetApi="21">2dp</item>
     </style>
 


### PR DESCRIPTION
## Issue
- close #346 

## Overview (Required)
- Ripple effect for Social Media Button on About page header
- It is enabled for after Lollipop
- There is already ripple effect for items on About page.


## Screenshot

This animation shows long press and release for Social Media Button 

<img src="https://user-images.githubusercontent.com/1014262/35194235-8abc7f1c-fef3-11e7-91a5-c1b9e86bd2b0.gif" width="300" />
