### PR TITLE
Incomplete Implementation of Notification Channel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -145,6 +145,11 @@
         </activity>
 
         <receiver android:name=".presentation.common.broadcastreceiver.NotificationBroadcastReceiver" />
+        <receiver android:name=".presentation.common.broadcastreceiver.LocaleChangedBroadcastReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.LOCALE_CHANGED" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/App.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/App.kt
@@ -15,6 +15,7 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasActivityInjector
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.di.AppInjector
+import io.github.droidkaigi.confsched2018.util.initNotificationChannel
 import timber.log.Timber
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig
 import javax.inject.Inject
@@ -31,6 +32,7 @@ open class App : MultiDexApplication(), HasActivityInjector {
         setupDagger()
         setupCalligraphy()
         setupEmoji()
+        setupNotification()
     }
 
     private fun setupFirebase() {
@@ -79,6 +81,10 @@ open class App : MultiDexApplication(), HasActivityInjector {
                     }
                 })
         EmojiCompat.init(config)
+    }
+
+    private fun setupNotification() {
+        initNotificationChannel(this)
     }
 
     override fun activityInjector(): DispatchingAndroidInjector<Activity> =

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/LocaleChangedBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/LocaleChangedBroadcastReceiver.kt
@@ -9,7 +9,7 @@ import timber.log.Timber
 class LocaleChangedBroadcastReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context?, intent: Intent?) {
         Timber.d("LocaleChangedBroadcastReceiver.onReceive")
-        if (Intent.ACTION_LOCALE_CHANGED == intent!!.action) {
+        if (Intent.ACTION_LOCALE_CHANGED == intent?.action) {
             initNotificationChannel(context!!)
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/LocaleChangedBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/LocaleChangedBroadcastReceiver.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched2018.presentation.common.broadcastreceiver
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.github.droidkaigi.confsched2018.util.initNotificationChannel
+import timber.log.Timber
+
+class LocaleChangedBroadcastReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {
+        Timber.d("LocaleChangedBroadcastReceiver.onReceive")
+        if (Intent.ACTION_LOCALE_CHANGED == intent!!.action) {
+            initNotificationChannel(context!!)
+        }
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/broadcastreceiver/NotificationBroadcastReceiver.kt
@@ -11,6 +11,7 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.presentation.MainActivity
 import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 import io.github.droidkaigi.confsched2018.presentation.detail.SessionDetailActivity
+import io.github.droidkaigi.confsched2018.util.NotificationUtil.ChannelType
 import io.github.droidkaigi.confsched2018.util.notificationBuilder
 import timber.log.Timber
 
@@ -26,13 +27,13 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         val sessionId = intent!!.getStringExtra(EXTRA_SESSION_ID)
         val title = intent.getStringExtra(EXTRA_TITLE)
         val text = intent.getStringExtra(EXTRA_TEXT)
-        val channelId = intent.getStringExtra(EXTRA_CHANNEL_ID)
+        val channelType = intent.getSerializableExtra(EXTRA_CHANNEL_TYPE) as ChannelType
         val pendingIntent = TaskStackBuilder
                 .create(context!!)
                 .addNextIntent(MainActivity.createIntent(context))
                 .addNextIntent(SessionDetailActivity.createIntent(context, sessionId))
                 .getPendingIntent(sessionId.hashCode(), PendingIntent.FLAG_UPDATE_CURRENT)
-        showNotification(context, title, text, pendingIntent, channelId)
+        showNotification(context, title, text, pendingIntent, channelType)
     }
 
     private fun showNotification(
@@ -40,7 +41,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
             title: String,
             text: String,
             pendingIntent: PendingIntent?,
-            channelId: String
+            channelId: ChannelType
     ) {
         val notification = notificationBuilder(context, channelId)
                 .setContentTitle(title)
@@ -58,19 +59,19 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         private const val EXTRA_SESSION_ID = "EXTRA_SESSION_ID"
         private const val EXTRA_TITLE = "EXTRA_TITLE"
         private const val EXTRA_TEXT = "EXTRA_TEXT"
-        private const val EXTRA_CHANNEL_ID = "EXTRA_CHANNEL_ID"
+        private const val EXTRA_CHANNEL_TYPE = "EXTRA_CHANNEL_TYPE"
         fun createIntent(
                 context: Context,
                 sessionId: String,
                 title: String,
                 text: String,
-                channelId: String
+                channelType: ChannelType
         ): Intent {
             return Intent(context, NotificationBroadcastReceiver::class.java).apply {
                 putExtra(EXTRA_SESSION_ID, sessionId)
                 putExtra(EXTRA_TITLE, title)
                 putExtra(EXTRA_TEXT, text)
-                putExtra(EXTRA_CHANNEL_ID, channelId)
+                putExtra(EXTRA_CHANNEL_TYPE, channelType)
             }
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
@@ -18,10 +18,7 @@ fun notificationBuilder(context: Context, channelId: String): NotificationCompat
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         createDefaultNotificationChannel(context, channelId)
     }
-    @Suppress("DEPRECATION")
-    val builder = NotificationCompat.Builder(context)
-    builder.setChannelId(channelId)
-    return builder
+    return NotificationCompat.Builder(context, channelId)
 }
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
@@ -29,7 +29,7 @@ fun initNotificationChannel(context: Context) {
 private fun createDefaultNotificationChannel(context: Context, channelId: String) {
     val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    val appName = context.getString(R.string.app_name)
+    val channelName = context.getString(R.string.notification_channel_name_start_favorite_session)
     val importance =
             when (channelId) {
                 NotificationUtil.FAVORITE_SESSION_START_CHANNEL_ID -> {
@@ -39,7 +39,7 @@ private fun createDefaultNotificationChannel(context: Context, channelId: String
                     NotificationManager.IMPORTANCE_DEFAULT
                 }
             }
-    val channel = NotificationChannel(channelId, appName, importance)
+    val channel = NotificationChannel(channelId, channelName, importance)
     notificationManager.createNotificationChannel(channel)
 }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
@@ -15,10 +15,14 @@ class NotificationUtil {
 }
 
 fun notificationBuilder(context: Context, channelId: String): NotificationCompat.Builder {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        createDefaultNotificationChannel(context, channelId)
-    }
     return NotificationCompat.Builder(context, channelId)
+}
+
+fun initNotificationChannel(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        createDefaultNotificationChannel(context,
+                NotificationUtil.FAVORITE_SESSION_START_CHANNEL_ID)
+    }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/NotificationUtil.kt
@@ -5,41 +5,40 @@ import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
 import android.support.annotation.RequiresApi
+import android.support.annotation.StringRes
 import android.support.v4.app.NotificationCompat
 import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.util.NotificationUtil.ChannelType
 
 class NotificationUtil {
-    companion object {
-        const val FAVORITE_SESSION_START_CHANNEL_ID = "favorite_session_start_channel"
+    enum class ChannelType(
+            val id: String,
+            @StringRes val nameRes: Int,
+            val importance: Int
+    ) {
+        FAVORITE_SESSION_START(
+                "favorite_session_start_channel",
+                R.string.notification_channel_name_start_favorite_session,
+                NotificationManager.IMPORTANCE_HIGH);
     }
 }
 
-fun notificationBuilder(context: Context, channelId: String): NotificationCompat.Builder {
-    return NotificationCompat.Builder(context, channelId)
+fun notificationBuilder(context: Context, channelType: ChannelType): NotificationCompat.Builder {
+    return NotificationCompat.Builder(context, channelType.id)
 }
 
 fun initNotificationChannel(context: Context) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        createDefaultNotificationChannel(context,
-                NotificationUtil.FAVORITE_SESSION_START_CHANNEL_ID)
+        createNotificationChannel(context, ChannelType.FAVORITE_SESSION_START)
     }
 }
 
 @RequiresApi(Build.VERSION_CODES.O)
-private fun createDefaultNotificationChannel(context: Context, channelId: String) {
+private fun createNotificationChannel(context: Context, channelType: ChannelType) {
     val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-    val channelName = context.getString(R.string.notification_channel_name_start_favorite_session)
-    val importance =
-            when (channelId) {
-                NotificationUtil.FAVORITE_SESSION_START_CHANNEL_ID -> {
-                    NotificationManager.IMPORTANCE_HIGH
-                }
-                else -> {
-                    NotificationManager.IMPORTANCE_DEFAULT
-                }
-            }
-    val channel = NotificationChannel(channelId, channelName, importance)
+    val channelName = context.getString(channelType.nameRes)
+    val channel = NotificationChannel(channelType.id, channelName, channelType.importance)
     notificationManager.createNotificationChannel(channel)
 }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/SessionAlarm.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/SessionAlarm.kt
@@ -56,7 +56,7 @@ class SessionAlarm @Inject constructor(val context: Context) {
                 session.id,
                 title,
                 text,
-                NotificationUtil.FAVORITE_SESSION_START_CHANNEL_ID
+                NotificationUtil.ChannelType.FAVORITE_SESSION_START
         )
         return PendingIntent.getBroadcast(
                 context,

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -86,6 +86,7 @@
     <!-- Notification -->
     <string name="notification_title">%1$s がもうすぐ始まります。</string>
     <string name="notification_message">%1$s ~ %2$s @ %3$s</string>
+    <string name="notification_channel_name_start_favorite_session">マイセッションの開始</string>
 
     <!-- AboutThisApp -->
     <string name="about_official_head_title">What is "DroidKaigi"?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <!-- Notification -->
     <string name="notification_title">%1$s will start soon</string>
     <string name="notification_message">%1$s ~ %2$s @ %3$s</string>
+    <string name="notification_channel_name_start_favorite_session">start favorite session</string>
 
     <!-- AboutThisApp -->
     <!-- TODO check if these English are all natural to international ppl. -->


### PR DESCRIPTION
## Issue
- close #312

## Overview (Required)
- (required) 
  - I replaced the deprecated constructor of NotificationBuilder with the recommended one.
  - The notification channel will be created when `Application.onCreated()` and received `Intent.ACTION_LOCALE_CHANGED`.
  - I renamed the channel name to `start favorite session(en)`/ `マイセッションの開始(ja)`.
- (optional)
  - For the good of type-safety, I created enum named `NotificationUtil.ChannelType`. 
  In addition, by this change, if a new channel type will be needed, just only creating an enum type will be required.

## Links
- https://developer.android.com/guide/topics/ui/notifiers/notifications.html#CreateChannel
- https://developer.android.com/reference/android/app/NotificationChannel.html#NotificationChannel(java.lang.String,%20java.lang.CharSequence,%20int)
- https://qiita.com/Shiozawa/items/095e77d38fc00681e898
- https://www.androidauthority.com/android-8-0-oreo-app-implementing-notification-channels-801097/

## Screenshot
- Notification setting screen(in the condition that the notification has been never shown)

Before | After(ja) | After(en)
:--: | :--: | :--:
<img width="200" alt="312_before" src="https://user-images.githubusercontent.com/26807657/35194314-14443990-fef5-11e7-938c-ec253f78b57b.png"> | <img width="200" alt="312_after_ja" src="https://user-images.githubusercontent.com/26807657/35194320-43486324-fef5-11e7-90ea-06f7d7ac2204.png"> | <img width="200" alt="312_after_en" src="https://user-images.githubusercontent.com/26807657/35194323-51b12c48-fef5-11e7-8646-8922e5a8d625.png">

