### PR TITLE
Fix margin of bottom navigation

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -30,6 +30,7 @@
             <FrameLayout
                 android:id="@+id/content"
                 style="@style/ContentFrameLayout"
+                app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
                 />
 
             <android.support.design.widget.BottomNavigationView


### PR DESCRIPTION
## Overview (Required)
The session Item was broken when scrolling to the bottom.
Since it had occurred at [this PR](https://github.com/DroidKaigi/conference-app-2018/pull/385/files#diff-03fed2eb51192f2b91ea135dd4d65600L36), I added the attribute again.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/35194412-87af2a6a-fef6-11e7-9da8-67462dd9173b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/35194414-87f8cdf0-fef6-11e7-9398-7dad0807903a.png" width="300" />
<img src="https://user-images.githubusercontent.com/11440952/35194411-878cf198-fef6-11e7-8b35-2d3781fb660b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/35194413-87d3a020-fef6-11e7-80d6-ab3e3609d631.png" width="300" />

