### PR TITLE
Use CoordinatorLayout to show SnackBar above BottomNavigationView

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,7 +27,7 @@
                 android:theme="@style/AppTheme.AppBarOverlay"
                 />
 
-            <FrameLayout
+            <android.support.design.widget.CoordinatorLayout
                 android:id="@+id/content"
                 style="@style/ContentFrameLayout"
                 app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"


### PR DESCRIPTION
## Overview (Required)
- Fix Snackbar hides BottomNavigationView

## Links
- https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-specs

## Screenshot
Before | After
:--: | :--:
![snackbar_over_bnv](https://user-images.githubusercontent.com/7608725/35194863-ba2ca8e4-fefd-11e7-8999-7a83278728e8.gif)  | ![snackbar_above_bnv](https://user-images.githubusercontent.com/7608725/35194878-12844222-fefe-11e7-9ecd-e85547415483.gif)

