### PR TITLE
Arrange social-media-buttons evenly

### DIFF
--- a/app/src/main/res/layout/item_about_this_app_header.xml
+++ b/app/src/main/res/layout/item_about_this_app_header.xml
@@ -80,8 +80,6 @@
         <ImageButton
             android:id="@+id/about_this_app_facebook"
             style="@style/SocialMediaButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
             android:layout_marginTop="32dp"
             android:contentDescription="facebook link button"
@@ -96,9 +94,6 @@
         <ImageButton
             android:id="@+id/about_this_app_twitter"
             style="@style/SocialMediaButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
             android:contentDescription="twitter link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_facebook"
             app:layout_constraintLeft_toRightOf="@+id/about_this_app_facebook"
@@ -110,9 +105,6 @@
         <ImageButton
             android:id="@+id/about_this_app_github"
             style="@style/SocialMediaButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
             android:contentDescription="github link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_twitter"
             app:layout_constraintLeft_toRightOf="@+id/about_this_app_twitter"
@@ -124,9 +116,6 @@
         <ImageButton
             android:id="@+id/about_this_app_youtube"
             style="@style/SocialMediaButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
             android:contentDescription="youtube link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_github"
             app:layout_constraintLeft_toRightOf="@+id/about_this_app_github"
@@ -139,9 +128,6 @@
         <ImageButton
             android:id="@+id/about_this_app_Medium"
             style="@style/SocialMediaButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
             android:contentDescription="medium link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_youtube"
             app:layout_constraintLeft_toRightOf="@+id/about_this_app_youtube"

--- a/app/src/main/res/layout/item_about_this_app_header.xml
+++ b/app/src/main/res/layout/item_about_this_app_header.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    >
     <data>
         <!-- TODO: add header specific dataset-->
         <variable
@@ -86,7 +86,9 @@
             android:layout_marginTop="32dp"
             android:contentDescription="facebook link button"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="@id/about_this_app_name"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toLeftOf="@id/about_this_app_twitter"
             app:layout_constraintTop_toBottomOf="@id/about_this_app_description"
             app:srcCompat="@drawable/ic_facebook_purple_24dp"
             />
@@ -99,7 +101,8 @@
             android:layout_marginStart="12dp"
             android:contentDescription="twitter link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_facebook"
-            app:layout_constraintStart_toEndOf="@id/about_this_app_facebook"
+            app:layout_constraintLeft_toRightOf="@+id/about_this_app_facebook"
+            app:layout_constraintRight_toLeftOf="@+id/about_this_app_github"
             app:layout_constraintTop_toTopOf="@id/about_this_app_facebook"
             app:srcCompat="@drawable/ic_twitter_blue_24dp"
             />
@@ -112,7 +115,8 @@
             android:layout_marginStart="12dp"
             android:contentDescription="github link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_twitter"
-            app:layout_constraintStart_toEndOf="@id/about_this_app_twitter"
+            app:layout_constraintLeft_toRightOf="@+id/about_this_app_twitter"
+            app:layout_constraintRight_toLeftOf="@+id/about_this_app_youtube"
             app:layout_constraintTop_toTopOf="@id/about_this_app_twitter"
             app:srcCompat="@drawable/ic_github_black_24dp"
             />
@@ -125,7 +129,8 @@
             android:layout_marginStart="12dp"
             android:contentDescription="youtube link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_github"
-            app:layout_constraintStart_toEndOf="@id/about_this_app_github"
+            app:layout_constraintLeft_toRightOf="@+id/about_this_app_github"
+            app:layout_constraintRight_toLeftOf="@+id/about_this_app_Medium"
             app:layout_constraintTop_toTopOf="@id/about_this_app_github"
             app:srcCompat="@drawable/ic_youtube_24dp"
             />
@@ -139,7 +144,8 @@
             android:layout_marginStart="12dp"
             android:contentDescription="medium link button"
             app:layout_constraintBottom_toBottomOf="@id/about_this_app_youtube"
-            app:layout_constraintStart_toEndOf="@id/about_this_app_youtube"
+            app:layout_constraintLeft_toRightOf="@+id/about_this_app_youtube"
+            app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintTop_toTopOf="@id/about_this_app_youtube"
             app:srcCompat="@drawable/ic_access_black_24dp"
             />

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -80,6 +80,8 @@
     </style>
 
     <style name="SocialMediaButton">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
         <item name="android:background">@drawable/bg_social_media_button</item>
         <item name="android:elevation" tools:targetApi="21">2dp</item>
     </style>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
Arrange social-media-buttons evenly with spread chain

## Links
- https://developer.android.com/reference/android/support/constraint/ConstraintLayout.html

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/11440952/35196288-415c3f7c-ff13-11e7-85a1-dda4ec7cf5af.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/35196290-41aaa982-ff13-11e7-84c0-2672ccbec09b.png" width="300" />
<img src="https://user-images.githubusercontent.com/11440952/35196287-41359408-ff13-11e7-882e-8543a2893422.png" width="300" /> | <img src="https://user-images.githubusercontent.com/11440952/35196289-418631b0-ff13-11e7-8706-1cd5bbc45bb7.png" width="300" />
