### PR TITLE
Add code style that do not wrap filed annotation

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -251,6 +251,7 @@
         </codeStyleSettings>
         <codeStyleSettings language="kotlin">
           <option name="METHOD_ANNOTATION_WRAP" value="1" />
+          <option name="FIELD_ANNOTATION_WRAP" value="1" />
         </codeStyleSettings>
       </value>
     </option>


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Add code style setting to not wrap field annotation

I usually wrap field annotation but this project dose not.
And my Android Studio wrap field annotation when run reformat code.
So add code style setting to prevent to wrap field annotation.

## Screenshot
Before | After
:--: | :--:
<img width="779" alt="2018-01-22 16 20 57" src="https://user-images.githubusercontent.com/7608725/35209346-c3f734c8-ff90-11e7-8c5f-a1ddf9405619.png"> | <img width="760" alt="2018-01-22 16 20 32" src="https://user-images.githubusercontent.com/7608725/35209350-ca309c4e-ff90-11e7-8e63-90c7ddb60352.png">

