### PR TITLE
Recover toolbar title after activity recreation

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -18,7 +18,6 @@ import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActiv
 import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
 import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLollipop
-import timber.log.Timber
 import javax.inject.Inject
 
 
@@ -49,22 +48,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
                     .values()
                     .first { it.menuId == item.itemId }
 
-            binding.toolbar.elevationForPostLollipop = if (navigationItem.isUseToolbarElevation) {
-                resources.getDimensionPixelSize(R.dimen.elevation_app_bar).toFloat()
-            } else {
-                0F
-            }
-            supportActionBar?.apply {
-                title = if (navigationItem.imageRes != null) {
-                    setDisplayShowHomeEnabled(true)
-                    setIcon(navigationItem.imageRes)
-                    null
-                } else {
-                    setDisplayShowHomeEnabled(false)
-                    setIcon(null)
-                    item.title
-                }
-            }
+            setupToolbar(navigationItem)
 
             navigationItem.navigate(navigationController)
             true
@@ -75,25 +59,30 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
         binding.bottomNavigation.setOnNavigationItemReselectedListener { }
     }
 
-    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
-        super.onRestoreInstanceState(savedInstanceState)
-        if (savedInstanceState != null) {
-            val navigationItem: BottomNavigationItem =
-                    BottomNavigationItem.forId(binding.bottomNavigation.selectedItemId)
-            Timber.d("menu: %s", navigationItem)
-            supportActionBar?.apply {
-                title = if (navigationItem.imageRes != null) {
-                    setDisplayShowHomeEnabled(true)
-                    setIcon(navigationItem.imageRes)
-                    null
-                } else {
-                    setDisplayShowHomeEnabled(false)
-                    setIcon(null)
-                    getString(navigationItem.titleRes!!)
-                }
+    private fun setupToolbar(navigationItem: BottomNavigationItem) {
+        binding.toolbar.elevationForPostLollipop = if (navigationItem.isUseToolbarElevation) {
+            resources.getDimensionPixelSize(R.dimen.elevation_app_bar).toFloat()
+        } else {
+            0F
+        }
+        supportActionBar?.apply {
+            title = if (navigationItem.imageRes != null) {
+                setDisplayShowHomeEnabled(true)
+                setIcon(navigationItem.imageRes)
+                null
+            } else {
+                setDisplayShowHomeEnabled(false)
+                setIcon(null)
+                getString(navigationItem.titleRes!!)
             }
         }
     }
+
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        setupToolbar(BottomNavigationItem.forId(binding.bottomNavigation.selectedItemId))
+    }
+
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
     override fun onBackPressed() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -45,8 +45,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
         binding.bottomNavigation.itemIconTintList = null
         binding.bottomNavigation.setOnNavigationItemSelectedListener({ item ->
             val navigationItem = BottomNavigationItem
-                    .values()
-                    .first { it.menuId == item.itemId }
+                    .forId(item.itemId)
 
             setupToolbar(navigationItem)
 
@@ -113,11 +112,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
 
         companion object {
             fun forId(@IdRes id: Int): BottomNavigationItem {
-                values().forEach {
-                    if (id == it.menuId)
-                        return it
-                }
-                throw IllegalArgumentException("wtf!")
+                return values().first { it.menuId == id }
             }
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -5,7 +5,9 @@ import android.content.Intent
 import android.databinding.DataBindingUtil
 import android.os.Bundle
 import android.support.annotation.DrawableRes
+import android.support.annotation.IdRes
 import android.support.annotation.MenuRes
+import android.support.annotation.StringRes
 import android.support.v4.app.Fragment
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -16,7 +18,10 @@ import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActiv
 import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
 import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLollipop
+import timber.log.Timber
 import javax.inject.Inject
+
+
 
 class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Fragment>
@@ -70,6 +75,25 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
         binding.bottomNavigation.setOnNavigationItemReselectedListener { }
     }
 
+    override fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        super.onRestoreInstanceState(savedInstanceState)
+        if (savedInstanceState != null) {
+            val navigationItem: BottomNavigationItem =
+                    BottomNavigationItem.forId(binding.bottomNavigation.selectedItemId)
+            Timber.d("menu: %s", navigationItem)
+            supportActionBar?.apply {
+                title = if (navigationItem.imageRes != null) {
+                    setDisplayShowHomeEnabled(true)
+                    setIcon(navigationItem.imageRes)
+                    null
+                } else {
+                    setDisplayShowHomeEnabled(false)
+                    setIcon(null)
+                    getString(navigationItem.titleRes!!)
+                }
+            }
+        }
+    }
     override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
 
     override fun onBackPressed() {
@@ -80,22 +104,33 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
 
     enum class BottomNavigationItem(
             @MenuRes val menuId: Int,
+            @StringRes val titleRes: Int?,
             @DrawableRes val imageRes: Int?,
             val isUseToolbarElevation: Boolean,
             val navigate: NavigationController.() -> Unit
     ) {
-        SESSION(R.id.navigation_sessions, R.drawable.ic_logo_white, false, {
+        SESSION(R.id.navigation_sessions,null,  R.drawable.ic_logo_white, false, {
             navigateToSessions()
         }),
-        SEARCH(R.id.navigation_search, null, false, {
+        SEARCH(R.id.navigation_search, R.string.search_title, null, false, {
             navigateToSearch()
         }),
-        FAVORITE(R.id.navigation_favorite_sessions, null, true, {
+        FAVORITE(R.id.navigation_favorite_sessions, R.string.favorite_title, null, true, {
             navigateToFavoriteSessions()
         }),
-        FEED(R.id.navigation_feed, null, true, {
+        FEED(R.id.navigation_feed, R.string.feed_title,null, true, {
             navigateToFeed()
-        })
+        });
+
+        companion object {
+            fun forId(@IdRes id: Int): BottomNavigationItem {
+                values().forEach {
+                    if (id == it.menuId)
+                        return it
+                }
+                throw IllegalArgumentException("wtf!")
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -20,8 +20,6 @@ import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLollipop
 import javax.inject.Inject
 
-
-
 class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Fragment>
 
@@ -97,7 +95,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
             val isUseToolbarElevation: Boolean,
             val navigate: NavigationController.() -> Unit
     ) {
-        SESSION(R.id.navigation_sessions,null,  R.drawable.ic_logo_white, false, {
+        SESSION(R.id.navigation_sessions, null, R.drawable.ic_logo_white, false, {
             navigateToSessions()
         }),
         SEARCH(R.id.navigation_search, R.string.search_title, null, false, {
@@ -106,7 +104,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
         FAVORITE(R.id.navigation_favorite_sessions, R.string.favorite_title, null, true, {
             navigateToFavoriteSessions()
         }),
-        FEED(R.id.navigation_feed, R.string.feed_title,null, true, {
+        FEED(R.id.navigation_feed, R.string.feed_title, null, true, {
             navigateToFeed()
         });
 


### PR DESCRIPTION
## Issue
- close #424 

## Overview (Required)
- As Toolbar does not save the logo state, we need to do it by ourselves.
- We need to wait for restoring the state of Toolbar so we are doing this recovery in Activity#onRestoreInstanceState
- Can be simplified...

## Links
- N/A

