### PR TITLE
Update thumb size to 16dp to avoid overlapped favorite button

### DIFF
--- a/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
+++ b/app/src/main/res/drawable/shape_fast_scroll_thumb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:left="40dp">
+    <item android:left="8dp">
         <shape android:shape="rectangle">
             <corners android:radius="8dp" />
             <solid android:color="@color/primary" />
@@ -10,7 +10,7 @@
     <item>
         <shape android:shape="rectangle">
             <solid android:color="@android:color/transparent" />
-            <size android:width="48dp" />
+            <size android:width="16dp" />
         </shape>
     </item>
 </layer-list>


### PR DESCRIPTION
## Issue
- close #425 

## Overview (Required)
- Change fast scroll thumbs touch area size to 16dp from 48dp