### PR TITLE
Change margin to padding for CollapsingToolbar

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -49,7 +49,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:fitsSystemWindows="true"
-                    android:layout_marginBottom="8dp"
+                    android:paddingBottom="8dp"
                     app:layout_scrollFlags="scroll|exitUntilCollapsed"
                     app:titleEnabled="false"
                     >


### PR DESCRIPTION
## Issue
- close #431 

## Overview (Required)
- Change margin to padding.
- (As other means, remove the margin.)

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/17231507/35223577-30eddd64-ffc5-11e7-8266-e2c2fa2673bb.gif) | ![after](https://user-images.githubusercontent.com/17231507/35223589-3adbe000-ffc5-11e7-95de-cd53d897ce1b.gif) 
