### PR TITLE
Fix initialization error on unit test

### DIFF
--- a/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSectionTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSectionTest.kt
@@ -15,7 +15,6 @@ import java.util.Date
 @RunWith(Enclosed::class)
 class DateSessionsSectionTest {
 
-    @RunWith(RobolectricTestRunner::class)
     abstract class BaseTest {
         lateinit var section: DateSessionsSection
 
@@ -40,6 +39,7 @@ class DateSessionsSectionTest {
         }
     }
 
+    @RunWith(RobolectricTestRunner::class)
     class UpdateSessionsTest : BaseTest() {
 
         @Test fun emptySessions() {
@@ -82,6 +82,7 @@ class DateSessionsSectionTest {
         }
     }
 
+    @RunWith(RobolectricTestRunner::class)
     class GateHeaderPositionByDateTest : BaseTest() {
 
         @Test fun emptySessions() {
@@ -122,6 +123,7 @@ class DateSessionsSectionTest {
         }
     }
 
+    @RunWith(RobolectricTestRunner::class)
     class GetDateNumberOrNullTest : BaseTest() {
 
         @Test fun emptySessions() {


### PR DESCRIPTION
## Issue
- close #428 

## Overview (Required)
- AndroidStudio does not seem to ignore `abstract class` annotated by `RunWith`.

## Links
- none

## Screenshot
none