### PR TITLE
Delete exit animations for custom tabs

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -141,11 +141,6 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
         val customTabsIntent = CustomTabsIntent.Builder()
                 .setShowTitle(true)
                 .setToolbarColor(ContextCompat.getColor(activity, R.color.primary))
-                .setExitAnimations(
-                        activity,
-                        android.R.anim.slide_in_left,
-                        android.R.anim.slide_out_right
-                )
                 .build()
                 .apply {
                     val appUri = Uri.parse("android-app://${activity.packageName}")


### PR DESCRIPTION
## Issue
no issue.

## Overview (Required)
Delete exit animations for custom tabs since the transition is different from start animations (and also the other activity's exit animations).

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/3589344/35227028-4863f40a-ffd0-11e7-8c73-90d0c8e3f6b0.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/3589344/35227044-53c4ffe2-ffd0-11e7-8869-1a1ca7aac8b7.gif" width="300" />
