### PR TITLE
Ft/Use @tools:sample/**

### DIFF
--- a/app/src/main/res/layout/fragment_speaker_detail.xml
+++ b/app/src/main/res/layout/fragment_speaker_detail.xml
@@ -37,7 +37,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:loadImage="@{speaker.imageUrl}"
             app:placeHolder="@{@drawable/ic_person_black_24dp}"
-            tools:src="@drawable/ic_person_black_24dp"
+            tools:src="@tools:sample/avatars"
             />
 
         <TextView
@@ -51,7 +51,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/speaker_image"
-            tools:text="takahirom"
+            tools:text="@tools:sample/full_names"
             />
         <TextView
             android:id="@+id/speaker_tag_line"

--- a/app/src/main/res/layout/item_contributor.xml
+++ b/app/src/main/res/layout/item_contributor.xml
@@ -28,7 +28,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:loadImage="@{contributor.avatarUrl}"
             app:placeHolder="@{@drawable/ic_person_black_24dp}"
-            tools:src="@drawable/ic_person_black_24dp"
+            tools:src="@tools:sample/avatars"
             />
         <TextView
             android:id="@+id/contributor_name"
@@ -41,7 +41,7 @@
             app:layout_constraintStart_toEndOf="@id/contributor_avatar"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
-            tools:text="First Family"
+            tools:text="@tools:sample/full_names"
             />
         <TextView
             android:id="@+id/contributor_bio"

--- a/app/src/main/res/layout/item_speaker.xml
+++ b/app/src/main/res/layout/item_speaker.xml
@@ -32,7 +32,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:loadImage="@{speaker.imageUrl}"
             app:placeHolder="@{@drawable/ic_person_black_24dp}"
-            tools:src="@drawable/ic_person_black_24dp"
+            tools:src="@tools:sample/avatars"
             />
         <TextView
             android:id="@+id/speaker_name"
@@ -46,7 +46,7 @@
             app:layout_constraintStart_toEndOf="@id/speaker_image"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
-            tools:text="Example"
+            tools:text="@tools:sample/last_names"
             />
         <TextView
             android:id="@+id/speaker_desc"

--- a/app/src/main/res/layout/item_speakers_summary_layout.xml
+++ b/app/src/main/res/layout/item_speakers_summary_layout.xml
@@ -38,7 +38,7 @@
             android:textAppearance="@style/TextAppearance.App.Body2"
             app:layout_constraintStart_toEndOf="@id/speaker_image"
             app:textColor="@color/app_bar_text_color"
-            tools:text="John Doe"
+            tools:text="@tools:sample/first_names"
             />
 
     </LinearLayout>

--- a/app/src/main/res/layout/item_staff.xml
+++ b/app/src/main/res/layout/item_staff.xml
@@ -28,7 +28,7 @@
             app:layout_constraintTop_toTopOf="parent"
             app:loadImage="@{staff.avatarUrl}"
             app:placeHolder="@{@drawable/ic_person_black_24dp}"
-            tools:src="@drawable/ic_person_black_24dp"
+            tools:src="@tools:sample/avatars"
             />
         <TextView
             android:id="@+id/staff_name"
@@ -43,7 +43,7 @@
             app:layout_constraintStart_toEndOf="@id/staff_avatar"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_chainStyle="packed"
-            tools:text="First Family"
+            tools:text="@tools:sample/first_names"
             />
 
         <View

--- a/app/src/main/res/layout/view_speakers_summary_layout.xml
+++ b/app/src/main/res/layout/view_speakers_summary_layout.xml
@@ -29,7 +29,7 @@
         android:layout_weight="1"
         android:ellipsize="end"
         android:maxLines="1"
-        tools:text="John Doe"
+        tools:text="@tools:sample/full_names"
         />
 
 </LinearLayout>


### PR DESCRIPTION
## Issue
- #441 

## Overview (Required)
Change `tools:text = "hogehoge"` to `tools:text: = @tools:sample/**`
I used sample for where I can adapt.

## Links
https://developer.android.com/studio/write/tool-attributes.html#toolssample_resources

## Screenshot
ex: `@tools:sample/avatars` and `@tools:sample/full_name`

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5400012/35273384-c93ad390-007b-11e8-8bf4-f60704a38240.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5400012/35273396-daf5cb26-007b-11e8-843a-8ea63e85b405.png" width="300" />
