### PR TITLE
Overlapping speaker and go to questionnaire button

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
@@ -56,7 +56,7 @@ class SpeakersSummaryLayout @JvmOverloads constructor(
         LayoutInflater.from(context).inflate(R.layout.view_speakers_summary_layout, this)
         speakerContainer = findViewById(R.id.speaker_container)
 
-        speakerContainer.setLayoutManager(LinearLayoutManager(context))
+        speakerContainer.layoutManager = LinearLayoutManager(context)
         setSpeakers(speakerList)
     }
 
@@ -82,7 +82,7 @@ class SpeakersSummaryLayout @JvmOverloads constructor(
     private fun updateSpeakers() {
         if (speakerList.isEmpty()) {
         } else {
-            var speakerAdapter = SpeakersAdapter(context, speakerList, customAttributes.textColor)
+            val speakerAdapter = SpeakersAdapter(context, speakerList, customAttributes.textColor)
             speakerContainer.adapter = speakerAdapter
 
             speakerAdapter.setOnItemClickListener(object : SpeakersAdapter.OnItemClickListener {

--- a/app/src/main/res/layout/item_speech_session.xml
+++ b/app/src/main/res/layout/item_speech_session.xml
@@ -180,7 +180,7 @@
                 android:visibility="@{session.isFinished ? View.VISIBLE : View.GONE}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/favorite"
+                app:layout_constraintTop_toBottomOf="@id/speaker_summary"
                 />
 
             <TextView


### PR DESCRIPTION
## Issue
- close #467 

## Overview (Required)
- Modified `item_speech_session.xml` so that `divider_finished_session` is drawn at the bottom of `speaker_summary`
- fix some warning of syntax according Kotlin rules

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8080435/35316564-b3771a2e-0115-11e8-840f-fa254aef4499.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8080435/35316549-9dcca9fa-0115-11e8-9a76-416149904322.png" width="300" />
