### PR TITLE
Hide BottomNavigationView by scrolling

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -8,6 +8,7 @@ import android.support.annotation.DrawableRes
 import android.support.annotation.IdRes
 import android.support.annotation.MenuRes
 import android.support.annotation.StringRes
+import android.support.design.widget.CoordinatorLayout
 import android.support.v4.app.Fragment
 import dagger.android.AndroidInjector
 import dagger.android.DispatchingAndroidInjector
@@ -16,6 +17,8 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ActivityMainBinding
 import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActivity
 import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
+import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+import io.github.droidkaigi.confsched2018.presentation.common.view.BottomNavigationBehavior
 import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLollipop
 import javax.inject.Inject
@@ -39,6 +42,11 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     }
 
     private fun setupBottomNavigation(savedInstanceState: Bundle?) {
+        if (Prefs.enableHideBottomNavigationBar) {
+
+            (binding.bottomNavigation.layoutParams as CoordinatorLayout.LayoutParams).behavior =
+                    BottomNavigationBehavior()
+        }
         binding.bottomNavigation.disableShiftMode()
         binding.bottomNavigation.itemIconTintList = null
         binding.bottomNavigation.setOnNavigationItemSelectedListener({ item ->

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -19,6 +19,7 @@ import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActiv
 import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
 import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.BottomNavigationBehavior
+import io.github.droidkaigi.confsched2018.presentation.common.view.BottomNavigationHideBehavior
 import io.github.droidkaigi.confsched2018.util.ext.disableShiftMode
 import io.github.droidkaigi.confsched2018.util.ext.elevationForPostLollipop
 import javax.inject.Inject
@@ -42,11 +43,12 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     }
 
     private fun setupBottomNavigation(savedInstanceState: Bundle?) {
-        if (Prefs.enableHideBottomNavigationBar) {
-
-            (binding.bottomNavigation.layoutParams as CoordinatorLayout.LayoutParams).behavior =
+        (binding.bottomNavigation.layoutParams as CoordinatorLayout.LayoutParams).behavior =
+                if (Prefs.enableHideBottomNavigationBar) {
+                    BottomNavigationHideBehavior()
+                } else {
                     BottomNavigationBehavior()
-        }
+                }
         binding.bottomNavigation.disableShiftMode()
         binding.bottomNavigation.itemIconTintList = null
         binding.bottomNavigation.setOnNavigationItemSelectedListener({ item ->

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -14,4 +14,8 @@ object Prefs : KotprefModel() {
             context.bool(R.bool.pref_default_value_enable_notification),
             R.string.pref_key_enable_notification
     )
+    var enableHideBottomNavigationBar: Boolean by booleanPref(
+            context.bool(R.bool.pref_default_value_enable_hide_bottom_navigation),
+            R.string.pref_key_enable_hide_bottom_navigation
+    )
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
@@ -1,60 +1,30 @@
 package io.github.droidkaigi.confsched2018.presentation.common.view
 
-import android.animation.Animator
 import android.content.Context
 import android.support.annotation.Keep
 import android.support.design.widget.BottomNavigationView
 import android.support.design.widget.CoordinatorLayout
 import android.support.design.widget.Snackbar
-import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.View
 
-class BottomNavigationBehavior : CoordinatorLayout.Behavior<BottomNavigationView> {
+/**
+ * Behavior to show Snackbar above BottomNavigationView
+ */
+open class BottomNavigationBehavior : CoordinatorLayout.Behavior<BottomNavigationView> {
 
+    // for set behavior on programmatically
     @Keep constructor() : super()
+
+    // for set behavior on XML
     @Keep constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
-    private var isAnimation: Boolean = false
     private var isSnackbarAppear: Boolean = false
     private var snackbar: Snackbar.SnackbarLayout? = null
-    private val animationListener = object : Animator.AnimatorListener {
-        override fun onAnimationRepeat(animation: Animator?) {
-        }
-
-        override fun onAnimationEnd(animation: Animator?) {
-            isAnimation = false
-        }
-
-        override fun onAnimationCancel(animation: Animator?) {
-            isAnimation = false
-        }
-
-        override fun onAnimationStart(animation: Animator?) {
-            isAnimation = true
-        }
-    }
 
     override fun layoutDependsOn(parent: CoordinatorLayout?, child: BottomNavigationView?,
                                  dependency: View?): Boolean {
         return dependency is Snackbar.SnackbarLayout
-    }
-
-    override fun onStartNestedScroll(coordinatorLayout: CoordinatorLayout,
-                                     child: BottomNavigationView, directTargetChild: View,
-                                     target: View, axes: Int, type: Int): Boolean {
-        return axes == ViewCompat.SCROLL_AXIS_VERTICAL
-    }
-
-    override fun onNestedScroll(coordinatorLayout: CoordinatorLayout, child: BottomNavigationView,
-                                target: View, dxConsumed: Int, dyConsumed: Int, dxUnconsumed: Int,
-                                dyUnconsumed: Int, type: Int) {
-        when {
-            dyConsumed > THRESHOLD_PX -> showBottomNavigationView(child)
-            dyConsumed < THRESHOLD_PX -> hideBottomNavigationView(child)
-            else -> Unit
-        }
-        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, type)
     }
 
     override fun onDependentViewChanged(parent: CoordinatorLayout?, child: BottomNavigationView?,
@@ -80,36 +50,11 @@ class BottomNavigationBehavior : CoordinatorLayout.Behavior<BottomNavigationView
         }
     }
 
-    private fun updateSnackBarPaddingBottomByBottomNavigationView(view: BottomNavigationView) {
+    internal fun updateSnackBarPaddingBottomByBottomNavigationView(view: BottomNavigationView) {
         snackbar?.apply {
             val translateY = (view.height - view.translationY).toInt()
             setPadding(paddingLeft, paddingTop, paddingRight, translateY)
             requestLayout()
         }
-    }
-
-    private fun hideBottomNavigationView(view: BottomNavigationView) {
-        if (isAnimation) return
-        view.animate().apply {
-            translationY(0f)
-            duration = DURATION_MILLIS
-            setListener(animationListener)
-            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
-        }
-    }
-
-    private fun showBottomNavigationView(view: BottomNavigationView) {
-        if (isAnimation) return
-        view.animate().apply {
-            translationY(view.height.toFloat())
-            duration = DURATION_MILLIS
-            setListener(animationListener)
-            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
-        }
-    }
-
-    companion object {
-        const val DURATION_MILLIS: Long = 150L
-        const val THRESHOLD_PX: Int = 0
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2018.presentation.common.view
 
 import android.animation.Animator
 import android.content.Context
+import android.support.annotation.Keep
 import android.support.design.widget.BottomNavigationView
 import android.support.design.widget.CoordinatorLayout
 import android.support.design.widget.Snackbar
@@ -9,8 +10,10 @@ import android.support.v4.view.ViewCompat
 import android.util.AttributeSet
 import android.view.View
 
-class BottomNavigationBehavior(context: Context, attrs: AttributeSet) :
-        CoordinatorLayout.Behavior<BottomNavigationView>(context, attrs) {
+class BottomNavigationBehavior : CoordinatorLayout.Behavior<BottomNavigationView> {
+
+    @Keep constructor() : super()
+    @Keep constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
 
     private var isAnimation: Boolean = false
     private var isSnackbarAppear: Boolean = false

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationBehavior.kt
@@ -1,0 +1,112 @@
+package io.github.droidkaigi.confsched2018.presentation.common.view
+
+import android.animation.Animator
+import android.content.Context
+import android.support.design.widget.BottomNavigationView
+import android.support.design.widget.CoordinatorLayout
+import android.support.design.widget.Snackbar
+import android.support.v4.view.ViewCompat
+import android.util.AttributeSet
+import android.view.View
+
+class BottomNavigationBehavior(context: Context, attrs: AttributeSet) :
+        CoordinatorLayout.Behavior<BottomNavigationView>(context, attrs) {
+
+    private var isAnimation: Boolean = false
+    private var isSnackbarAppear: Boolean = false
+    private var snackbar: Snackbar.SnackbarLayout? = null
+    private val animationListener = object : Animator.AnimatorListener {
+        override fun onAnimationRepeat(animation: Animator?) {
+        }
+
+        override fun onAnimationEnd(animation: Animator?) {
+            isAnimation = false
+        }
+
+        override fun onAnimationCancel(animation: Animator?) {
+            isAnimation = false
+        }
+
+        override fun onAnimationStart(animation: Animator?) {
+            isAnimation = true
+        }
+    }
+
+    override fun layoutDependsOn(parent: CoordinatorLayout?, child: BottomNavigationView?,
+                                 dependency: View?): Boolean {
+        return dependency is Snackbar.SnackbarLayout
+    }
+
+    override fun onStartNestedScroll(coordinatorLayout: CoordinatorLayout,
+                                     child: BottomNavigationView, directTargetChild: View,
+                                     target: View, axes: Int, type: Int): Boolean {
+        return axes == ViewCompat.SCROLL_AXIS_VERTICAL
+    }
+
+    override fun onNestedScroll(coordinatorLayout: CoordinatorLayout, child: BottomNavigationView,
+                                target: View, dxConsumed: Int, dyConsumed: Int, dxUnconsumed: Int,
+                                dyUnconsumed: Int, type: Int) {
+        when {
+            dyConsumed > THRESHOLD_PX -> showBottomNavigationView(child)
+            dyConsumed < THRESHOLD_PX -> hideBottomNavigationView(child)
+            else -> Unit
+        }
+        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed, type)
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout?, child: BottomNavigationView?,
+                                        dependency: View?): Boolean {
+        if (dependency is Snackbar.SnackbarLayout) {
+            if (isSnackbarAppear) return true
+            isSnackbarAppear = true
+            snackbar = dependency
+            child?.let { updateSnackBarPaddingBottomByBottomNavigationView(it) }
+            return true
+        }
+        return false
+    }
+
+    override fun onDependentViewRemoved(parent: CoordinatorLayout?, child: BottomNavigationView?,
+                                        dependency: View?) {
+        when (dependency) {
+            is Snackbar.SnackbarLayout -> {
+                isSnackbarAppear = false
+                snackbar = null
+            }
+            else -> super.onDependentViewRemoved(parent, child, dependency)
+        }
+    }
+
+    private fun updateSnackBarPaddingBottomByBottomNavigationView(view: BottomNavigationView) {
+        snackbar?.apply {
+            val translateY = (view.height - view.translationY).toInt()
+            setPadding(paddingLeft, paddingTop, paddingRight, translateY)
+            requestLayout()
+        }
+    }
+
+    private fun hideBottomNavigationView(view: BottomNavigationView) {
+        if (isAnimation) return
+        view.animate().apply {
+            translationY(0f)
+            duration = DURATION_MILLIS
+            setListener(animationListener)
+            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
+        }
+    }
+
+    private fun showBottomNavigationView(view: BottomNavigationView) {
+        if (isAnimation) return
+        view.animate().apply {
+            translationY(view.height.toFloat())
+            duration = DURATION_MILLIS
+            setListener(animationListener)
+            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
+        }
+    }
+
+    companion object {
+        const val DURATION_MILLIS: Long = 150L
+        const val THRESHOLD_PX: Int = 0
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationHideBehavior.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/BottomNavigationHideBehavior.kt
@@ -1,0 +1,79 @@
+package io.github.droidkaigi.confsched2018.presentation.common.view
+
+import android.animation.Animator
+import android.content.Context
+import android.support.annotation.Keep
+import android.support.design.widget.BottomNavigationView
+import android.support.design.widget.CoordinatorLayout
+import android.support.v4.view.ViewCompat
+import android.util.AttributeSet
+import android.view.View
+
+/**
+ * Behavior to hide BottomNavigationView
+ */
+class BottomNavigationHideBehavior : BottomNavigationBehavior {
+    @Keep constructor() : super()
+    @Keep constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    private var isAnimation: Boolean = false
+    private val animationListener = object : Animator.AnimatorListener {
+        override fun onAnimationRepeat(animation: Animator?) {
+        }
+
+        override fun onAnimationEnd(animation: Animator?) {
+            isAnimation = false
+        }
+
+        override fun onAnimationCancel(animation: Animator?) {
+            isAnimation = false
+        }
+
+        override fun onAnimationStart(animation: Animator?) {
+            isAnimation = true
+        }
+    }
+
+    override fun onStartNestedScroll(coordinatorLayout: CoordinatorLayout,
+                                     child: BottomNavigationView, directTargetChild: View,
+                                     target: View, axes: Int, type: Int): Boolean {
+        return axes == ViewCompat.SCROLL_AXIS_VERTICAL
+    }
+
+    override fun onNestedScroll(coordinatorLayout: CoordinatorLayout, child: BottomNavigationView,
+                                target: View, dxConsumed: Int, dyConsumed: Int, dxUnconsumed: Int,
+                                dyUnconsumed: Int, type: Int) {
+        when {
+            dyConsumed > THRESHOLD_PX -> showBottomNavigationView(child)
+            dyConsumed < THRESHOLD_PX -> hideBottomNavigationView(child)
+            else -> Unit
+        }
+        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed,
+                dxUnconsumed, dyUnconsumed, type)
+    }
+
+    private fun hideBottomNavigationView(view: BottomNavigationView) {
+        if (isAnimation) return
+        view.animate().apply {
+            translationY(0f)
+            duration = DURATION_MILLIS
+            setListener(animationListener)
+            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
+        }
+    }
+
+    private fun showBottomNavigationView(view: BottomNavigationView) {
+        if (isAnimation) return
+        view.animate().apply {
+            translationY(view.height.toFloat())
+            duration = DURATION_MILLIS
+            setListener(animationListener)
+            setUpdateListener { updateSnackBarPaddingBottomByBottomNavigationView(view) }
+        }
+    }
+
+    companion object {
+        const val DURATION_MILLIS: Long = 150L
+        const val THRESHOLD_PX: Int = 0
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/ContentWithBottomNavigationBehavior.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/ContentWithBottomNavigationBehavior.kt
@@ -1,0 +1,66 @@
+package io.github.droidkaigi.confsched2018.presentation.common.view
+
+import android.content.Context
+import android.support.design.widget.BottomNavigationView
+import android.support.design.widget.CoordinatorLayout
+import android.util.AttributeSet
+import android.view.View
+import android.view.ViewGroup
+
+/**
+ * This behavior specified for ViewGroup used in activity_main.xml id=content.
+ * Be carefully to use other ViewGroup.
+ */
+class ContentWithBottomNavigationBehavior(context: Context, attrs: AttributeSet) :
+        CoordinatorLayout.Behavior<ViewGroup>(context, attrs) {
+    private var previousHeight: Float = 0f
+    private var requestResetBnv: Boolean = false
+
+    override fun onMeasureChild(parent: CoordinatorLayout, child: ViewGroup,
+                                parentWidthMeasureSpec: Int, widthUsed: Int,
+                                parentHeightMeasureSpec: Int, heightUsed: Int): Boolean {
+        val bnv: BottomNavigationView = parent.getDependencies(child)
+                .firstOrNull { it is BottomNavigationView } as? BottomNavigationView
+        // this behavior specified for ViewGroup used with BottomNavigationView
+                ?: return super.onMeasureChild(parent, child, parentWidthMeasureSpec,
+                        widthUsed, parentHeightMeasureSpec, heightUsed)
+
+        // avoid the content is overlapped by BottomNavigationView
+        // compute content area size to fits to BNV upper line
+
+        // compute CoordinatorLayout height
+        val parentMeasureSpecHeight = View.MeasureSpec.getSize(parentHeightMeasureSpec)
+        val availableHeight =
+                if (parentMeasureSpecHeight == 0) parent.height else parentMeasureSpecHeight
+
+        // compute BottomNavigationView height
+        // translationY == 0 means BNV perfectly showed so content area fits to BNV upper line
+        // otherwise BNV is going to hide and content area fits to CoordinatorLayout bottom line
+        // if use BNV's just height we cannot scroll smoothly.
+        val bnvHeight = if (bnv.translationY == 0f) bnv.height else 0
+
+        val heightMeasureSpec = View.MeasureSpec.makeMeasureSpec(availableHeight - bnvHeight,
+                View.MeasureSpec.EXACTLY)
+        parent.onMeasureChild(child, parentWidthMeasureSpec, widthUsed,
+                heightMeasureSpec, heightUsed)
+        return true
+    }
+
+    override fun layoutDependsOn(parent: CoordinatorLayout?, child: ViewGroup?,
+                                 dependency: View?): Boolean {
+        return dependency is BottomNavigationView
+    }
+
+    override fun onDependentViewChanged(parent: CoordinatorLayout?, child: ViewGroup?,
+                                        dependency: View?): Boolean {
+        if (dependency is BottomNavigationView) {
+            val height = dependency.height - dependency.translationY
+            if (previousHeight != height) {
+                child?.requestLayout()
+                previousHeight = height
+            }
+            return true
+        }
+        return super.onDependentViewChanged(parent, child, dependency)
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,24 +27,27 @@
                 android:theme="@style/AppTheme.AppBarOverlay"
                 />
 
-            <android.support.design.widget.CoordinatorLayout
-                android:id="@+id/content"
-                style="@style/ContentFrameLayout"
-                app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
-                />
+            <android.support.design.widget.CoordinatorLayout style="@style/ContentFrameLayout">
 
-            <android.support.design.widget.BottomNavigationView
-                android:id="@+id/bottom_navigation"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="0dp"
-                android:layout_marginStart="0dp"
-                android:background="?android:attr/windowBackground"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toRightOf="parent"
-                app:menu="@menu/bottom_navigation"
-                />
+                <FrameLayout
+                    android:id="@+id/content"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    />
+
+                <android.support.design.widget.BottomNavigationView
+                    android:id="@+id/bottom_navigation"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="bottom"
+                    android:layout_marginEnd="0dp"
+                    android:layout_marginStart="0dp"
+                    android:background="?android:attr/windowBackground"
+                    app:layout_behavior="io.github.droidkaigi.confsched2018.presentation.common.view.BottomNavigationBehavior"
+                    app:menu="@menu/bottom_navigation"
+                    />
+
+            </android.support.design.widget.CoordinatorLayout>
 
         </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -43,7 +43,6 @@
                     android:layout_marginEnd="0dp"
                     android:layout_marginStart="0dp"
                     android:background="?android:attr/windowBackground"
-                    app:layout_behavior="io.github.droidkaigi.confsched2018.presentation.common.view.BottomNavigationBehavior"
                     app:menu="@menu/bottom_navigation"
                     />
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -33,6 +33,7 @@
                     android:id="@+id/content"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    app:layout_behavior="io.github.droidkaigi.confsched2018.presentation.common.view.ContentWithBottomNavigationBehavior"
                     />
 
                 <android.support.design.widget.BottomNavigationView

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -74,6 +74,8 @@
     <string name="settings_enable_local_time_summary_preference">DroidKaigiの現地時間の代わりに現在地の時間を使用します。</string>
     <string name="settings_enable_notification_title_preference">通知を受信する</string>
     <string name="settings_enable_notification_summary_preference">このアプリで通知を受信するかどうかを選択できます。</string>
+    <string name="settings_enable_hide_bottom_navigation_title_preference">BottomNavigationを隠す</string>
+    <string name="settings_enable_hide_bottom_navigation_summary_preference">BottomNavigationBarをスクロールにあわせて隠すかどうかを選択できます。</string>
 
     <!-- Speaker -->
     <string name="speaker_title_activity_detail">スピーカー</string>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -2,5 +2,5 @@
 <resources>
     <bool name="pref_default_value_enable_local_time">false</bool>
     <bool name="pref_default_value_enable_notification">true</bool>
-    <bool name="pref_default_value_enable_hide_bottom_navigation">false</bool>
+    <bool name="pref_default_value_enable_hide_bottom_navigation">true</bool>
 </resources>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -2,4 +2,5 @@
 <resources>
     <bool name="pref_default_value_enable_local_time">false</bool>
     <bool name="pref_default_value_enable_notification">true</bool>
+    <bool name="pref_default_value_enable_hide_bottom_navigation">false</bool>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <!-- Preference Keys -->
     <string name="pref_key_enable_local_time" translatable="false">pref_key_enable_local_time</string>
     <string name="pref_key_enable_notification" translatable="false">pref_key_enable_notification</string>
+    <string name="pref_key_enable_hide_bottom_navigation" translatable="false">pref_key_enable_hide_bottom_navigation</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_home">Home</string>
@@ -83,6 +84,9 @@
     <string name="settings_enable_notification_summary_preference">Choose whether to receive
         notification in this app.</string>
     <string name="settings_enable_notification_title_preference">Receive notification</string>
+    <string name="settings_enable_hide_bottom_navigation_title_preference">Hide BottomNavigation</string>
+    <string name="settings_enable_hide_bottom_navigation_summary_preference">Hide
+        BottomNavigationBar by scrolling or not.</string>
 
     <!-- Speaker -->
     <string name="speaker_title_activity_detail">Speaker</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -12,4 +12,10 @@
         android:summary="@string/settings_enable_notification_summary_preference"
         android:title="@string/settings_enable_notification_title_preference"
         />
+    <android.support.v7.preference.SwitchPreferenceCompat
+        android:defaultValue="@bool/pref_default_value_enable_hide_bottom_navigation"
+        android:key="@string/pref_key_enable_hide_bottom_navigation"
+        android:summary="@string/settings_enable_hide_bottom_navigation_summary_preference"
+        android:title="@string/settings_enable_hide_bottom_navigation_title_preference"
+        />
 </PreferenceScreen>


### PR DESCRIPTION
## Overview (Required)

I implemented the behavior that BottomNavigationView hide by scrolling.
This feature gives users the benefit that a wider screen can be used.
I think it is more convenient for the user if BNV is fixed, so I chose this feature as optional (default: BNV fixed).

## Links
- https://material.io/guidelines/components/bottom-navigation.html#bottom-navigation-behavior

## Screenshot
![hide_bnv_by_scrolling](https://user-images.githubusercontent.com/7608725/35318350-3cb907d6-011e-11e8-9840-2470f54f1d29.gif)

## Detail

- It is optional, user can select BNV fixed or hide by scroll
- Default: fixed
- Snackbar appears from above BNV whether it is fixed
- Snackbar follows the BNV if it is hiding

## Issue

If you accept this PR,  it has some issues:

-  Change settings to use hide BNV behavior, it will be not apply until next launch. (related issue #435 )
- 検索 > セッションのページで横にスクロールするRecyclerViewの上で縦スクロールを行った場合にBNVが隠れない

It looks to be apply immediately on above movie, but it is enabled developer settings "Don't keep Activity".

It is not an essential feature so it's OK to feel free to kick it 😄 