### PR TITLE
Add session feedback screen without design

### DIFF
--- a/app/schemas/io.github.droidkaigi.confsched2018.data.db.AppDatabase/6.json
+++ b/app/schemas/io.github.droidkaigi.confsched2018.data.db.AppDatabase/6.json
@@ -1,0 +1,353 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "5b9cb42652b6813a5d5e0b8abc21fa21",
+    "entities": [
+      {
+        "tableName": "contributor",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `bio` TEXT, `avatarUrl` TEXT NOT NULL, `htmlUrl` TEXT NOT NULL, `contributions` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bio",
+            "columnName": "bio",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "htmlUrl",
+            "columnName": "htmlUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "contributions",
+            "columnName": "contributions",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "session",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `desc` TEXT NOT NULL, `stime` INTEGER NOT NULL, `etime` INTEGER NOT NULL, `sessionFormat` TEXT NOT NULL, `language` TEXT NOT NULL, `level_id` INTEGER NOT NULL, `level_name` TEXT NOT NULL, `topic_id` INTEGER NOT NULL, `topic_name` TEXT NOT NULL, `room_id` INTEGER NOT NULL, `room_name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "desc",
+            "columnName": "desc",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stime",
+            "columnName": "stime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "etime",
+            "columnName": "etime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionFormat",
+            "columnName": "sessionFormat",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "language",
+            "columnName": "language",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level.id",
+            "columnName": "level_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "level.name",
+            "columnName": "level_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic.id",
+            "columnName": "topic_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "topic.name",
+            "columnName": "topic_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "room.id",
+            "columnName": "room_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "room.name",
+            "columnName": "room_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "speaker",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `speaker_name` TEXT NOT NULL, `speaker_tag_line` TEXT NOT NULL, `speaker_image_url` TEXT NOT NULL, `speaker_twitter_url` TEXT, `speaker_company_url` TEXT, `speaker_blog_url` TEXT, `speaker_github_url` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "speaker_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagLine",
+            "columnName": "speaker_tag_line",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "speaker_image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "twitterUrl",
+            "columnName": "speaker_twitter_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "companyUrl",
+            "columnName": "speaker_company_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blogUrl",
+            "columnName": "speaker_blog_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "githubUrl",
+            "columnName": "speaker_github_url",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "session_speaker_join",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sessionId` TEXT NOT NULL, `speakerId` TEXT NOT NULL, PRIMARY KEY(`sessionId`, `speakerId`), FOREIGN KEY(`sessionId`) REFERENCES `session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`speakerId`) REFERENCES `speaker`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "speakerId",
+            "columnName": "speakerId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sessionId",
+            "speakerId"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_session_speaker_join_speakerId",
+            "unique": false,
+            "columnNames": [
+              "speakerId"
+            ],
+            "createSql": "CREATE  INDEX `index_session_speaker_join_speakerId` ON `${TABLE_NAME}` (`speakerId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "speaker",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "speakerId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "session_feedback",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`session_id` TEXT NOT NULL, `total_evaluation` INTEGER NOT NULL, `relevancy` INTEGER NOT NULL, `asExpected` INTEGER NOT NULL, `difficulty` INTEGER NOT NULL, `knowledgeable` INTEGER NOT NULL, `comment` TEXT NOT NULL, `submitted` INTEGER NOT NULL, PRIMARY KEY(`session_id`), FOREIGN KEY(`session_id`) REFERENCES `session`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "sessionId",
+            "columnName": "session_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalEvaluation",
+            "columnName": "total_evaluation",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relevancy",
+            "columnName": "relevancy",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "asExpected",
+            "columnName": "asExpected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "difficulty",
+            "columnName": "difficulty",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "knowledgeable",
+            "columnName": "knowledgeable",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "comment",
+            "columnName": "comment",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "submitted",
+            "columnName": "submitted",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "session_id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_session_feedback_session_id",
+            "unique": false,
+            "columnNames": [
+              "session_id"
+            ],
+            "createSql": "CREATE  INDEX `index_session_feedback_session_id` ON `${TABLE_NAME}` (`session_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "session",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "session_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, \"5b9cb42652b6813a5d5e0b8abc21fa21\")"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,6 +40,15 @@
                 />
         </activity>
         <activity
+            android:name=".presentation.sessions.feedback.SessionsFeedbackActivity"
+            android:parentActivityName=".presentation.MainActivity"
+            >
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".presentation.sessions.feedback.SessionsFeedbackActivity"
+                />
+        </activity>
+        <activity
             android:name=".presentation.map.MapActivity"
             android:label="@string/map_title_activity"
             android:parentActivityName=".presentation.MainActivity"

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/SessionFeedbackApi.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/SessionFeedbackApi.kt
@@ -14,7 +14,7 @@ interface SessionFeedbackApi {
     @FormUrlEncoded
     fun submitSessionFeedback(
 
-            @Field("entry.1298546024") sessionId: Int,
+            @Field("entry.1298546024") sessionId: String,
             @Field("entry.413792998") sessionTitle: String,
 
             // セッションはどうでしたか？(総合評価)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/SessionDataMapperExt.kt
@@ -27,7 +27,6 @@ fun List<Session>?.toSessionSpeakerJoinEntities(): List<SessionSpeakerJoinEntity
 
 fun SessionFeedback.toSessionFeedbackEntity(): SessionFeedbackEntity {
     return SessionFeedbackEntity(
-            id = null,
             sessionId = sessionId,
             totalEvaluation = totalEvaluation,
             relevancy = relevancy,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/AppDatabase.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/AppDatabase.kt
@@ -23,7 +23,7 @@ import io.github.droidkaigi.confsched2018.data.db.entity.mapper.Converters
             (SessionSpeakerJoinEntity::class),
             (SessionFeedbackEntity::class)
         ],
-        version = 5
+        version = 6
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/SessionFeedbackEntity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/SessionFeedbackEntity.kt
@@ -12,8 +12,7 @@ import android.arch.persistence.room.PrimaryKey
                 childColumns = arrayOf("session_id"),
                 onDelete = ForeignKey.CASCADE))])
 data class SessionFeedbackEntity(
-        @PrimaryKey(autoGenerate = true) val id: Int?,
-        @ColumnInfo(name = "session_id", index = true) val sessionId: String,
+        @PrimaryKey @ColumnInfo(name = "session_id", index = true) val sessionId: String,
         @ColumnInfo(name = "total_evaluation") var totalEvaluation: Int,
         var relevancy: Int,
         var asExpected: Int,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -3,12 +3,14 @@ package io.github.droidkaigi.confsched2018.data.db.entity.mapper
 import android.annotation.SuppressLint
 import android.support.annotation.VisibleForTesting
 import io.github.droidkaigi.confsched2018.data.db.entity.RoomEntity
+import io.github.droidkaigi.confsched2018.data.db.entity.SessionFeedbackEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.SessionWithSpeakers
 import io.github.droidkaigi.confsched2018.data.db.entity.SpeakerEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.TopicEntity
 import io.github.droidkaigi.confsched2018.model.Level
 import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
 import io.github.droidkaigi.confsched2018.util.ext.toUnixMills
@@ -46,6 +48,18 @@ fun SessionWithSpeakers.toSession(
             speakers = speakers
     )
 }
+
+fun SessionFeedbackEntity.toSessionFeedback(): SessionFeedback = SessionFeedback(
+        sessionId = sessionId,
+        sessionTitle = "",
+        totalEvaluation = totalEvaluation,
+        relevancy = relevancy,
+        asExpected = asExpected,
+        difficulty = difficulty,
+        knowledgeable = knowledgeable,
+        comment = comment,
+        submitted = submitted
+)
 
 fun SpeakerEntity.toSpeaker(): Speaker = Speaker(
         id = id,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -83,10 +83,10 @@ class SessionDataRepository @Inject constructor(
                             .doOnNext { if (DEBUG) Timber.d("getAllSessionFeedback") },
                     { sessionEntities, sessionFeedbackEntities ->
                         sessionFeedbackEntities.map { sessionFeedback ->
-                            sessionFeedback.toSessionFeedback().apply {
+                            sessionFeedback.toSessionFeedback().also {
                                 sessionEntities.forEach { sessionWithSpeaker ->
-                                    if (sessionId == sessionWithSpeaker.session!!.id) {
-                                        sessionTitle = sessionWithSpeaker.session!!.title
+                                    if (it.sessionId == sessionWithSpeaker.session!!.id) {
+                                        it.copy(sessionTitle = sessionWithSpeaker.session!!.title)
                                     }
                                 }
                             }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -75,18 +75,18 @@ class SessionDataRepository @Inject constructor(
 
     override val sessionFeedbacks: Flowable<List<SessionFeedback>> =
             Flowables.zip(
-                    sessionDatabase.getAllSessions()
-                            .filter { it.isNotEmpty() }
-                            .doOnNext { if (DEBUG) Timber.d("getAllSessions") },
+                    sessions.map { sessionList ->
+                        sessionList.filterIsInstance<Session.SpeechSession>()
+                    },
                     sessionDatabase.getAllSessionFeedback()
                             .map { if (it.isNotEmpty()) it else emptyList() }
                             .doOnNext { if (DEBUG) Timber.d("getAllSessionFeedback") },
-                    { sessionEntities, sessionFeedbackEntities ->
+                    { speechSessions, sessionFeedbackEntities ->
                         sessionFeedbackEntities.map { sessionFeedback ->
                             sessionFeedback.toSessionFeedback().also {
-                                sessionEntities.forEach { sessionWithSpeaker ->
-                                    if (it.sessionId == sessionWithSpeaker.session!!.id) {
-                                        it.copy(sessionTitle = sessionWithSpeaker.session!!.title)
+                                speechSessions.forEach { speechSession ->
+                                    if (it.sessionId == speechSession.id) {
+                                        it.copy(sessionTitle = speechSession.title)
                                     }
                                 }
                             }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -86,7 +86,7 @@ class SessionDataRepository @Inject constructor(
                             sessionFeedback.toSessionFeedback().also {
                                 speechSessions.forEach { speechSession ->
                                     if (it.sessionId == speechSession.id) {
-                                        it.copy(sessionTitle = speechSession.title)
+                                        return@map it.copy(sessionTitle = speechSession.title)
                                     }
                                 }
                             }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionRepository.kt
@@ -5,11 +5,13 @@ import io.github.droidkaigi.confsched2018.model.Level
 import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.SearchResult
 import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
 import io.reactivex.Completable
 import io.reactivex.Flowable
 import io.reactivex.Single
+import retrofit2.Response
 
 interface SessionRepository {
     val sessions: Flowable<List<Session>>
@@ -17,6 +19,7 @@ interface SessionRepository {
     val roomSessions: Flowable<Map<Room, List<Session>>>
     val rooms: Flowable<List<Room>>
     val topics: Flowable<List<Topic>>
+    val sessionFeedbacks: Flowable<List<SessionFeedback>>
     val speakerSessions: Flowable<Map<Speaker, List<Session.SpeechSession>>>
     val topicSessions: Flowable<Map<Topic, List<Session.SpeechSession>>>
     val levelSessions: Flowable<Map<Level, List<Session.SpeechSession>>>
@@ -24,4 +27,6 @@ interface SessionRepository {
     @CheckResult fun refreshSessions(): Completable
     @CheckResult fun favorite(session: Session.SpeechSession): Single<Boolean>
     @CheckResult fun search(query: String): Single<SearchResult>
+    @CheckResult fun saveSessionFeedback(sessionFeedback: SessionFeedback): Completable
+    @CheckResult fun submitSessionFeedback(sessionFeedback: SessionFeedback): Single<Response<Void>>
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppComponent.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppComponent.kt
@@ -32,7 +32,8 @@ import javax.inject.Singleton
     SponsorsActivityBuilder::class,
     SessionDetailActivityBuilder::class,
     SpeakerDetailActivityBuilder::class,
-    TopicDetailActivityBuilder::class
+    TopicDetailActivityBuilder::class,
+    SessionsFeedbackActivityBuilder::class
 ])
 interface AppComponent {
     @Component.Builder

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/AppModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import io.github.droidkaigi.confsched2018.data.api.DroidKaigiApi
 import io.github.droidkaigi.confsched2018.data.api.FeedApi
 import io.github.droidkaigi.confsched2018.data.api.GithubApi
+import io.github.droidkaigi.confsched2018.data.api.SessionFeedbackApi
 import io.github.droidkaigi.confsched2018.data.db.ContributorDatabase
 import io.github.droidkaigi.confsched2018.data.db.FavoriteDatabase
 import io.github.droidkaigi.confsched2018.data.db.SessionDatabase
@@ -32,11 +33,13 @@ internal object AppModule {
     @Singleton @Provides @JvmStatic
     fun provideSessionRepository(
             api: DroidKaigiApi,
+            sessionFeedbackApi: SessionFeedbackApi,
             sessionDatabase: SessionDatabase,
             favoriteDatabase: FavoriteDatabase,
             schedulerProvider: SchedulerProvider
     ): SessionRepository =
-            SessionDataRepository(api, sessionDatabase, favoriteDatabase, schedulerProvider)
+            SessionDataRepository(api, sessionFeedbackApi, sessionDatabase, favoriteDatabase,
+                    schedulerProvider)
 
     @Singleton @Provides @JvmStatic
     fun provideFeedRepository(

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/FragmentBuildersModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/FragmentBuildersModule.kt
@@ -15,13 +15,15 @@ import io.github.droidkaigi.confsched2018.presentation.search.SearchTopicsFragme
 import io.github.droidkaigi.confsched2018.presentation.sessions.AllSessionsFragment
 import io.github.droidkaigi.confsched2018.presentation.sessions.RoomSessionsFragment
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackFragment
 import io.github.droidkaigi.confsched2018.presentation.settings.SettingsFragment
 import io.github.droidkaigi.confsched2018.presentation.speaker.SpeakerDetailFragment
 import io.github.droidkaigi.confsched2018.presentation.sponsors.SponsorsFragment
 import io.github.droidkaigi.confsched2018.presentation.staff.StaffFragment
 import io.github.droidkaigi.confsched2018.presentation.topic.TopicDetailFragment
 
-@Module interface FragmentBuildersModule {
+@Module
+interface FragmentBuildersModule {
     @ContributesAndroidInjector fun contributeSessionsFragment(): SessionsFragment
 
     @ContributesAndroidInjector fun contributeAllSessionsFragment(): AllSessionsFragment
@@ -61,4 +63,6 @@ import io.github.droidkaigi.confsched2018.presentation.topic.TopicDetailFragment
     @ContributesAndroidInjector fun contributeContributorFragment(): ContributorsFragment
 
     @ContributesAndroidInjector fun contributeStaffFragment(): StaffFragment
+
+    @ContributesAndroidInjector fun contributeSessionsFeedbackFragment(): SessionsFeedbackFragment
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/SessionsFeedbackActivityBuilder.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/SessionsFeedbackActivityBuilder.kt
@@ -1,0 +1,16 @@
+package io.github.droidkaigi.confsched2018.di
+
+import dagger.Module
+import dagger.android.ContributesAndroidInjector
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackActivity
+
+@Module
+interface SessionsFeedbackActivityBuilder {
+    @ContributesAndroidInjector(
+            modules = [
+                FragmentBuildersModule::class,
+                SessionsFeedbackActivityModule::class
+            ]
+    )
+    fun contributeSessionsFeedbackActivity(): SessionsFeedbackActivity
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/SessionsFeedbackActivityModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/SessionsFeedbackActivityModule.kt
@@ -1,0 +1,11 @@
+package io.github.droidkaigi.confsched2018.di
+
+import android.support.v7.app.AppCompatActivity
+import dagger.Binds
+import dagger.Module
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackActivity
+
+@Module
+interface SessionsFeedbackActivityModule {
+    @Binds fun providesAppCompatActivity(activity: SessionsFeedbackActivity): AppCompatActivity
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/ViewModelModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/ViewModelModule.kt
@@ -16,6 +16,7 @@ import io.github.droidkaigi.confsched2018.presentation.search.SearchViewModel
 import io.github.droidkaigi.confsched2018.presentation.sessions.AllSessionsViewModel
 import io.github.droidkaigi.confsched2018.presentation.sessions.RoomSessionsViewModel
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsViewModel
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackViewModel
 import io.github.droidkaigi.confsched2018.presentation.speaker.SpeakerDetailViewModel
 import io.github.droidkaigi.confsched2018.presentation.sponsors.SponsorsViewModel
 import io.github.droidkaigi.confsched2018.presentation.staff.StaffViewModel
@@ -98,6 +99,10 @@ interface ViewModelModule {
     @Binds @IntoMap
     @ViewModelKey(SponsorsViewModel::class)
     fun bindSponsorsViewModel(sponsorsViewModel: SponsorsViewModel): ViewModel
+
+    @Binds @IntoMap
+    @ViewModelKey(SessionsFeedbackViewModel::class)
+    fun bindSessionFeedbackViewModel(sessionFeedbackViewModel: SessionsFeedbackViewModel): ViewModel
 
     @Binds fun bindViewModelFactory(factory: ViewModelFactory): ViewModelProvider.Factory
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -21,6 +21,8 @@ import io.github.droidkaigi.confsched2018.presentation.map.MapActivity
 import io.github.droidkaigi.confsched2018.presentation.map.MapFragment
 import io.github.droidkaigi.confsched2018.presentation.search.SearchFragment
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackActivity
+import io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackFragment
 import io.github.droidkaigi.confsched2018.presentation.settings.SettingsActivity
 import io.github.droidkaigi.confsched2018.presentation.settings.SettingsFragment
 import io.github.droidkaigi.confsched2018.presentation.speaker.SpeakerDetailActivity
@@ -56,6 +58,10 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
 
     fun navigateToDetail(sessionId: String) {
         replaceFragment(SessionDetailFragment.newInstance(sessionId))
+    }
+
+    fun navigateToFeedback(sessionId: String, sessionTitle: String) {
+        replaceFragment(SessionsFeedbackFragment.newInstance(sessionId, sessionTitle))
     }
 
     fun navigateToMap() {
@@ -111,6 +117,10 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
 
     fun navigateToSessionDetailActivity(session: Session) {
         SessionDetailActivity.start(activity, session)
+    }
+
+    fun navigateToSessionsFeedbackActivity(session: Session.SpeechSession) {
+        SessionsFeedbackActivity.start(activity, session)
     }
 
     fun navigateToMapActivity() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
@@ -51,6 +51,10 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         binding = FragmentFavoriteSessionsBinding.inflate(inflater, container, false)
@@ -72,7 +76,7 @@ class FavoriteSessionsFragment : Fragment(), Injectable {
                     progressTimeLatch.loading = false
                     val sessions = result.data
                     sessionsSection.updateSessions(
-                            sessions, onFavoriteClickListener)
+                            sessions, onFavoriteClickListener, onQuestionnaireListener)
                     binding.mysessionInactiveGroup.setVisible(sessions.isEmpty())
                     binding.sessionsRecycler.setVisible(sessions.isNotEmpty())
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -58,6 +58,10 @@ class SearchFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
@@ -91,6 +95,7 @@ class SearchFragment : Fragment(), Injectable {
                     sessionsSection.updateSessions(
                             searchResult.sessions,
                             onFavoriteClickListener,
+                            onQuestionnaireListener,
                             searchViewModel.searchQuery
                     )
                     speakersSection.updateSpeakers(

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -57,6 +57,10 @@ class AllSessionsFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         binding = FragmentAllSessionsBinding.inflate(inflater, container, false)
@@ -76,7 +80,8 @@ class AllSessionsFragment : Fragment(), Injectable {
             when (result) {
                 is Result.Success -> {
                     val sessions = result.data
-                    sessionsSection.updateSessions(sessions, onFavoriteClickListener, true)
+                    sessionsSection.updateSessions(sessions, onFavoriteClickListener,
+                            onQuestionnaireListener, true)
 
                     sessionsViewModel.onSuccessFetchSessions()
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -59,6 +59,10 @@ class RoomSessionsFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         roomName = arguments!!.getString(ARG_ROOM_NAME)
@@ -83,7 +87,8 @@ class RoomSessionsFragment : Fragment(), Injectable {
             when (result) {
                 is Result.Success -> {
                     val sessions = result.data
-                    sessionsSection.updateSessions(sessions, onFavoriteClickListener, true)
+                    sessionsSection.updateSessions(sessions, onFavoriteClickListener,
+                            onQuestionnaireListener, true)
 
                     sessionsViewModel.onSuccessFetchSessions()
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackActivity.kt
@@ -1,0 +1,58 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.feedback
+
+import android.content.Context
+import android.content.Intent
+import android.databinding.DataBindingUtil
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import dagger.android.AndroidInjector
+import dagger.android.DispatchingAndroidInjector
+import dagger.android.support.HasSupportFragmentInjector
+import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.databinding.ActivitySessionsFeedbackBinding
+import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.presentation.NavigationController
+import io.github.droidkaigi.confsched2018.presentation.common.activity.BaseActivity
+import io.github.droidkaigi.confsched2018.presentation.common.menu.DrawerMenu
+import javax.inject.Inject
+
+class SessionsFeedbackActivity : BaseActivity(), HasSupportFragmentInjector {
+
+    @Inject lateinit var dispatchingAndroidInjector: DispatchingAndroidInjector<Fragment>
+    @Inject lateinit var navigationController: NavigationController
+    @Inject lateinit var drawerMenu: DrawerMenu
+
+    private val binding: ActivitySessionsFeedbackBinding by lazy {
+        DataBindingUtil.setContentView<ActivitySessionsFeedbackBinding>(this, R.layout.activity_sessions_feedback)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.title = intent.getStringExtra(EXTRA_SESSION_TITLE)
+
+        navigationController.navigateToFeedback(
+                intent.getStringExtra(EXTRA_SESSION_ID), intent.getStringExtra(EXTRA_SESSION_TITLE))
+        drawerMenu.setup(binding.drawerLayout, binding.drawer, binding.toolbar)
+    }
+
+    override fun supportFragmentInjector(): AndroidInjector<Fragment> = dispatchingAndroidInjector
+
+    override fun onBackPressed() {
+        if (drawerMenu.closeDrawerIfNeeded()) {
+            super.onBackPressed()
+        }
+    }
+
+    companion object {
+        const val EXTRA_SESSION_ID = "EXTRA_SESSION_ID"
+        const val EXTRA_SESSION_TITLE = "EXTRA_SESSION_TITLE"
+        fun start(context: Context, session: Session.SpeechSession) {
+            context.startActivity(Intent(context, SessionsFeedbackActivity::class.java).apply {
+                putExtra(EXTRA_SESSION_ID, session.id)
+                putExtra(EXTRA_SESSION_TITLE, session.title)
+            })
+        }
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackFragment.kt
@@ -1,0 +1,100 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.feedback
+
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import io.github.droidkaigi.confsched2018.databinding.FragmentSessionsFeedbackBinding
+import io.github.droidkaigi.confsched2018.di.Injectable
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
+import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.util.ext.observe
+import timber.log.Timber
+import javax.inject.Inject
+
+class SessionsFeedbackFragment : Fragment(), Injectable {
+
+    @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+
+    private lateinit var binding: FragmentSessionsFeedbackBinding
+
+    private val sessionsFeedbackViewModel: SessionsFeedbackViewModel by lazy {
+        ViewModelProviders.of(this, viewModelFactory).get(SessionsFeedbackViewModel::class.java)
+    }
+
+    private val onSubmitListener = { sessionFeedback: SessionFeedback ->
+        sessionsFeedbackViewModel.onSubmit(sessionFeedback)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
+                              savedInstanceState: Bundle?): View? {
+        binding = FragmentSessionsFeedbackBinding.inflate(
+                inflater,
+                container!!,
+                false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        sessionsFeedbackViewModel.sessionId = arguments!!.getString(EXTRA_SESSION_ID)
+        sessionsFeedbackViewModel.sessionTitle = arguments!!.getString(EXTRA_SESSION_TITLE)
+
+        sessionsFeedbackViewModel.mutableSessionFeedback.observe(this, { result ->
+            when (result) {
+                is Result.Success -> {
+                    binding.sessionFeedback = result.data
+                }
+                is Result.Failure -> {
+                    Timber.e(result.e)
+                }
+            }
+        })
+
+        binding.editText.addTextChangedListener(object : TextWatcher {
+            override fun afterTextChanged(p0: Editable?) {
+            }
+
+            override fun beforeTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+            }
+
+            override fun onTextChanged(p0: CharSequence?, p1: Int, p2: Int, p3: Int) {
+                if (p0.isNullOrBlank()) {
+                    return
+                }
+
+                sessionsFeedbackViewModel.onSessionFeedbackChanged(sessionsFeedbackViewModel
+                        .sessionFeedback.copy(totalEvaluation = Integer.parseInt(p0.toString())))
+            }
+        })
+
+        binding.submit.setOnClickListener {
+            onSubmitListener(sessionsFeedbackViewModel.sessionFeedback)
+        }
+
+        sessionsFeedbackViewModel.init()
+    }
+
+    override fun onDetach() {
+        sessionsFeedbackViewModel.save()
+        super.onDetach()
+    }
+
+    companion object {
+        const val EXTRA_SESSION_ID = "EXTRA_SESSION_ID"
+        const val EXTRA_SESSION_TITLE = "EXTRA_SESSION_TITLE"
+        fun newInstance(sessionId: String, sessionTitle: String): SessionsFeedbackFragment =
+                SessionsFeedbackFragment().apply {
+                    arguments = Bundle().apply {
+                        putString(EXTRA_SESSION_ID, sessionId)
+                        putString(EXTRA_SESSION_TITLE, sessionTitle)
+                    }
+                }
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackViewModel.kt
@@ -1,0 +1,70 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.feedback
+
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
+import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.presentation.common.mapper.toResult
+import io.github.droidkaigi.confsched2018.util.rx.SchedulerProvider
+import io.reactivex.Observable
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.addTo
+import javax.inject.Inject
+
+class SessionsFeedbackViewModel @Inject constructor(
+        private val repository: SessionRepository,
+        private val schedulerProvider: SchedulerProvider
+) : ViewModel() {
+
+    var sessionId: String = ""
+    var sessionTitle: String = ""
+
+    lateinit var sessionFeedback: SessionFeedback
+    var mutableSessionFeedback = MutableLiveData<Result<SessionFeedback>>()
+
+    private val compositeDisposable: CompositeDisposable = CompositeDisposable()
+
+    fun init() {
+        repository.sessionFeedbacks
+                .map { sessionFeedbacks ->
+                    sessionFeedback = sessionFeedbacks.firstOrNull { it.sessionId == sessionId }
+                            ?: SessionFeedback(sessionId, sessionTitle, 0, 0, 0, 0, 0, "", false)
+                    sessionFeedback
+                }
+                .toResult(schedulerProvider)
+                .subscribe {
+                    mutableSessionFeedback.value = it
+                }
+                .addTo(compositeDisposable)
+
+    }
+
+    fun onSessionFeedbackChanged(sessionFeedback: SessionFeedback) {
+        this.sessionFeedback = sessionFeedback
+        Observable.just(this.sessionFeedback)
+                .toResult(schedulerProvider)
+                .subscribe {
+                    mutableSessionFeedback.value = it
+                }
+                .addTo(compositeDisposable)
+    }
+
+    fun save() {
+        repository.saveSessionFeedback(sessionFeedback)
+                .subscribe()
+                .addTo(compositeDisposable)
+    }
+
+    fun onSubmit(sessionFeedback: SessionFeedback) {
+        // TODO: if submit success, add to save local DB change sessionFeedback.submitted = ture
+        repository.submitSessionFeedback(sessionFeedback)
+                .subscribe()
+                .addTo(compositeDisposable)
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.clear()
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSection.kt
@@ -10,7 +10,9 @@ class DateSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session>,
             onFavoriteClickListener: (Session.SpeechSession) -> Unit,
-            isShowDayNumber: Boolean = false
+            onQuestionnaireListener: (Session.SpeechSession) -> Unit,
+            isShowDayNumber: Boolean = false,
+            simplify: Boolean = false
     ) {
         val sessionItems = sessions.map {
             when (it) {
@@ -19,6 +21,7 @@ class DateSessionsSection : Section() {
                     SpeechSessionItem(
                             session = it,
                             onFavoriteClickListener = onFavoriteClickListener,
+                            onQuestionnaireListener = onQuestionnaireListener,
                             isShowDayNumber = isShowDayNumber
                     ) as SessionItem
                 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/FavoriteSessionsSection.kt
@@ -9,12 +9,14 @@ import java.util.SortedMap
 class FavoriteSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session.SpeechSession>,
-            onFavoriteClickListener: (Session.SpeechSession) -> Unit
+            onFavoriteClickListener: (Session.SpeechSession) -> Unit,
+            onQuestionnaireListener: (Session.SpeechSession) -> Unit
     ) {
         val sessionItems = sessions.map {
             SpeechSessionItem(
                     it,
                     onFavoriteClickListener,
+                    onQuestionnaireListener,
                     simplify = true)
         }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SimpleSessionsSection.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SimpleSessionsSection.kt
@@ -8,6 +8,7 @@ class SimpleSessionsSection : Section() {
     fun updateSessions(
             sessions: List<Session>,
             onFavoriteClickListener: (Session.SpeechSession) -> Unit,
+            onQuestionnaireListener: (Session.SpeechSession) -> Unit,
             searchQuery: String = "",
             userIdInDetail: String? = null
     ) {
@@ -18,6 +19,7 @@ class SimpleSessionsSection : Section() {
                     SpeechSessionItem(
                             session = it,
                             onFavoriteClickListener = onFavoriteClickListener,
+                            onQuestionnaireListener = onQuestionnaireListener,
                             isShowDayNumber = true,
                             searchQuery = searchQuery,
                             userIdInDetail = userIdInDetail

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SpeechSessionItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/SpeechSessionItem.kt
@@ -11,6 +11,7 @@ import io.github.droidkaigi.confsched2018.util.ext.drawable
 data class SpeechSessionItem(
         override val session: Session.SpeechSession,
         private val onFavoriteClickListener: (Session.SpeechSession) -> Unit,
+        private val onQuestionnaireListener: (Session.SpeechSession) -> Unit,
         private val isShowDayNumber: Boolean = false,
         private val searchQuery: String = "",
         private val simplify: Boolean = false,
@@ -30,7 +31,7 @@ data class SpeechSessionItem(
         viewBinding.isShowDayNumber = isShowDayNumber
         viewBinding.simplify = simplify
         viewBinding.goToQuestionnaire.setOnClickListener {
-            //TODO: will implement this. Please check comments of issue #141
+            onQuestionnaireListener(session)
         }
         val levelDrawable = viewBinding.context.drawable(when (session.level) {
             is Level.Beginner -> R.drawable.ic_beginner_lightgreen_20dp

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
@@ -41,6 +41,10 @@ class SpeakerDetailFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         binding =
@@ -63,6 +67,7 @@ class SpeakerDetailFragment : Fragment(), Injectable {
                     binding.speaker = speaker
                     sessionsSection.updateSessions(result.data.second,
                             onFavoriteClickListener,
+                            onQuestionnaireListener,
                             userIdInDetail = speaker.id)
                 }
                 is Result.Failure -> {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/topic/TopicDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/topic/TopicDetailFragment.kt
@@ -42,6 +42,10 @@ class TopicDetailFragment : Fragment(), Injectable {
         sessionAlarm.toggleRegister(session)
     }
 
+    private val onQuestionnaireListener = { session: Session.SpeechSession ->
+        navigationController.navigateToSessionsFeedbackActivity(session)
+    }
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?,
                               savedInstanceState: Bundle?): View? {
         binding = FragmentTopicDetailBinding.inflate(
@@ -59,7 +63,7 @@ class TopicDetailFragment : Fragment(), Injectable {
         topicDetailViewModel.topicSessions.observe(this, { result ->
             when (result) {
                 is Result.Success -> {
-                    sessionsSection.updateSessions(result.data.second, onFavoriteClickListener)
+                    sessionsSection.updateSessions(result.data.second, onFavoriteClickListener, onQuestionnaireListener)
                 }
                 is Result.Failure -> {
                     Timber.e(result.e)

--- a/app/src/main/res/layout/activity_sessions_feedback.xml
+++ b/app/src/main/res/layout/activity_sessions_feedback.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackActivity"
+    >
+    <data></data>
+    <android.support.v4.widget.DrawerLayout
+        android:id="@+id/drawer_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true"
+        tools:openDrawer="start"
+        >
+        <android.support.constraint.ConstraintLayout
+            android:id="@+id/container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            >
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:titleTextColor="@color/app_bar_text_color"
+                />
+
+            <FrameLayout
+                android:id="@+id/content"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                />
+        </android.support.constraint.ConstraintLayout>
+
+        <android.support.design.widget.NavigationView
+            android:id="@+id/drawer"
+            style="@style/DrawerNavigation"
+            app:headerLayout="@layout/drawer_header"
+            app:menu="@menu/drawer"
+            />
+    </android.support.v4.widget.DrawerLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_sessions_feedback.xml
+++ b/app/src/main/res/layout/fragment_sessions_feedback.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+
+    <data>
+        <variable
+            name="sessionFeedback"
+            type="io.github.droidkaigi.confsched2018.model.SessionFeedback"
+            />
+    </data>
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context="io.github.droidkaigi.confsched2018.presentation.sessions.feedback.SessionsFeedbackActivity"
+        tools:showIn="@layout/activity_sessions_feedback"
+        >
+
+        <!-- TODO: apply session feedback rating view -->
+        <TextView
+            android:id="@+id/label_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SessionId:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+        <TextView
+            android:id="@+id/id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{sessionFeedback.sessionId}"
+            app:layout_constraintStart_toEndOf="@id/label_id"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="123456"
+            />
+
+        <TextView
+            android:id="@+id/label_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="SessionTitle:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/id"
+            />
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{sessionFeedback.sessionTitle}"
+            app:layout_constraintStart_toEndOf="@id/label_title"
+            app:layout_constraintTop_toBottomOf="@id/id"
+            tools:text="title"
+            />
+
+        <TextView
+            android:id="@+id/label_total_evaluation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="TotalEvaluation:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            />
+
+        <TextView
+            android:id="@+id/total_evaluation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{Integer.toString(sessionFeedback.totalEvaluation)}"
+            app:layout_constraintStart_toEndOf="@id/label_total_evaluation"
+            app:layout_constraintTop_toBottomOf="@id/title"
+            tools:text="totalEvaluation"
+            />
+
+        <TextView
+            android:id="@+id/label_relevancy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Relevancy:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/total_evaluation"
+            />
+
+        <TextView
+            android:id="@+id/relevancy"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{Integer.toString(sessionFeedback.relevancy)}"
+            app:layout_constraintStart_toEndOf="@id/label_relevancy"
+            app:layout_constraintTop_toBottomOf="@id/total_evaluation"
+            tools:text="relevancy"
+            />
+
+        <TextView
+            android:id="@+id/label_as_expected"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="AsExpected:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/relevancy"
+            />
+
+        <TextView
+            android:id="@+id/as_expected"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{Integer.toString(sessionFeedback.asExpected)}"
+            app:layout_constraintStart_toEndOf="@id/label_as_expected"
+            app:layout_constraintTop_toBottomOf="@id/relevancy"
+            tools:text="asExpected"
+            />
+
+        <TextView
+            android:id="@+id/label_difficulty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Difficulty:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/as_expected"
+            />
+
+        <TextView
+            android:id="@+id/difficulty"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{Integer.toString(sessionFeedback.difficulty)}"
+            app:layout_constraintStart_toEndOf="@id/label_difficulty"
+            app:layout_constraintTop_toBottomOf="@id/as_expected"
+            tools:text="difficulty"
+            />
+
+        <TextView
+            android:id="@+id/label_knowledgeable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Knowledgeable:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/difficulty"
+            />
+
+        <TextView
+            android:id="@+id/knowledgeable"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{Integer.toString(sessionFeedback.difficulty)}"
+            app:layout_constraintStart_toEndOf="@id/label_knowledgeable"
+            app:layout_constraintTop_toBottomOf="@id/difficulty"
+            tools:text="knowledgeable"
+            />
+
+        <TextView
+            android:id="@+id/label_comment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Comment:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/knowledgeable"
+            />
+
+        <TextView
+            android:id="@+id/comment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{sessionFeedback.comment}"
+            app:layout_constraintStart_toEndOf="@id/label_comment"
+            app:layout_constraintTop_toBottomOf="@id/knowledgeable"
+            tools:text="comment"
+            />
+
+        <TextView
+            android:id="@+id/label_submitted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Submitted:"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/comment"
+            />
+
+        <TextView
+            android:id="@+id/submitted"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:text="@{String.valueOf(sessionFeedback.submitted)}"
+            app:layout_constraintStart_toEndOf="@id/label_submitted"
+            app:layout_constraintTop_toBottomOf="@id/comment"
+            tools:text="submitted"
+            />
+
+        <EditText
+            android:id="@+id/editText"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            android:inputType="number"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/knowledgeable"
+            />
+
+        <Button
+            android:id="@+id/submit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@string/submit_feedback"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/editText"
+            />
+
+        <ProgressBar
+            android:id="@+id/progress"
+            style="@style/ProgressBar"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            />
+
+    </android.support.constraint.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -116,4 +116,7 @@
     <string name="about_contributors_description">App制作に携わった人たちです。</string>
     <string name="about_version_title">開発情報</string>
     <string name="about_version_description">%1$s</string>
+
+    <!-- Session Feedback -->
+    <string name="submit_feedback">フィードバックを送る</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -132,4 +132,7 @@
     <string name="about_contributors_description">Those who contribute to creation.</string>
     <string name="about_version_title">Version</string>
     <string name="about_version_description">%1$s</string>
+
+    <!-- Session Feedback -->
+    <string name="submit_feedback">Submit feedback</string>
 </resources>

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
@@ -54,7 +54,6 @@ fun createDummySession(sessionId: String = DUMMY_SESSION_ID1,
 fun createDummySessionFeedbackEntities(): List<SessionFeedbackEntity> {
     return listOf(
             SessionFeedbackEntity(
-                    id = 1,
                     sessionId = DUMMY_SESSION_ID1,
                     totalEvaluation = 1,
                     relevancy = 1,
@@ -64,7 +63,6 @@ fun createDummySessionFeedbackEntities(): List<SessionFeedbackEntity> {
                     comment = "comment",
                     submitted = false),
             SessionFeedbackEntity(
-                    id = 2,
                     sessionId = DUMMY_SESSION_ID2,
                     totalEvaluation = 3,
                     relevancy = 3,

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
@@ -3,12 +3,14 @@ package io.github.droidkaigi.confsched2018
 import io.github.droidkaigi.confsched2018.data.db.entity.LevelEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.RoomEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.SessionEntity
+import io.github.droidkaigi.confsched2018.data.db.entity.SessionFeedbackEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.SessionWithSpeakers
 import io.github.droidkaigi.confsched2018.data.db.entity.SpeakerEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.TopicEntity
 import io.github.droidkaigi.confsched2018.model.Level
 import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
 import org.threeten.bp.LocalDateTime
@@ -47,6 +49,47 @@ fun createDummySession(sessionId: String = DUMMY_SESSION_ID1,
             createDummySpeaker()
     )
     )
+}
+
+fun createDummySessionFeedbackEntities(): List<SessionFeedbackEntity> {
+    return listOf(
+            SessionFeedbackEntity(
+                    id = 1,
+                    sessionId = DUMMY_SESSION_ID1,
+                    totalEvaluation = 1,
+                    relevancy = 1,
+                    asExpected = 1,
+                    difficulty = 1,
+                    knowledgeable = 1,
+                    comment = "comment",
+                    submitted = false),
+            SessionFeedbackEntity(
+                    id = 2,
+                    sessionId = DUMMY_SESSION_ID2,
+                    totalEvaluation = 3,
+                    relevancy = 3,
+                    asExpected = 3,
+                    difficulty = 3,
+                    knowledgeable = 3,
+                    comment = "comment",
+                    submitted = false)
+    )
+
+}
+
+fun createDummySessionFeedback(sessionId: String = DUMMY_SESSION_ID1,
+                               sessionTitle: String = DUMMY_SESSION_TITLE1): SessionFeedback {
+    return SessionFeedback(
+            sessionId = sessionId,
+            sessionTitle = sessionTitle,
+            totalEvaluation = 1,
+            relevancy = 1,
+            asExpected = 1,
+            difficulty = 1,
+            knowledgeable = 1,
+            comment = "comment",
+            submitted = false)
+
 }
 
 fun createDummySpecialSession(dayNumber: Int = 1,

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/data/repository/SessionsDataRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/data/repository/SessionsDataRepositoryTest.kt
@@ -125,7 +125,7 @@ class SessionsDataRepositoryTest {
                             sessionFeedback.toSessionFeedback().also {
                                 sessions.forEach { session ->
                                     if (it.sessionId == session.id) {
-                                        it.copy(sessionTitle = session.title)
+                                        return@map it.copy(sessionTitle = session.title)
                                     }
                                 }
                             }

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/data/repository/SessionsDataRepositoryTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/data/repository/SessionsDataRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import io.github.droidkaigi.confsched2018.DUMMY_SESSION_TITLE1
+import io.github.droidkaigi.confsched2018.createDummySessionFeedbackEntities
 import io.github.droidkaigi.confsched2018.createDummySessionWithSpeakersEntities
 import io.github.droidkaigi.confsched2018.createDummySpeakerEntities
 import io.github.droidkaigi.confsched2018.createDummySpeakerEntry1
@@ -15,6 +16,7 @@ import io.github.droidkaigi.confsched2018.data.db.entity.RoomEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.TopicEntity
 import io.github.droidkaigi.confsched2018.data.db.entity.mapper.toRooms
 import io.github.droidkaigi.confsched2018.data.db.entity.mapper.toSession
+import io.github.droidkaigi.confsched2018.data.db.entity.mapper.toSessionFeedback
 import io.github.droidkaigi.confsched2018.data.db.entity.mapper.toSpeaker
 import io.github.droidkaigi.confsched2018.data.db.entity.mapper.toTopics
 import io.github.droidkaigi.confsched2018.data.db.fixeddata.SpecialSessions
@@ -37,6 +39,7 @@ class SessionsDataRepositoryTest {
         whenever(sessionDatabase.getAllTopic()).doReturn(Flowable.just(mock()))
         whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(mock()))
         whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(mock()))
+        whenever(sessionDatabase.getAllSessionFeedback()).doReturn(Flowable.just(mock()))
         whenever(favoriteDatabase.favorites).doReturn(Flowable.just(emptyList()))
     }
 
@@ -44,6 +47,7 @@ class SessionsDataRepositoryTest {
         val rooms = listOf(RoomEntity(1, "A"), RoomEntity(2, "B"))
         whenever(sessionDatabase.getAllRoom()).doReturn(Flowable.just(rooms))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())
@@ -60,6 +64,7 @@ class SessionsDataRepositoryTest {
         val topics = listOf(TopicEntity(1, "topic_a"), TopicEntity(2, "topic_b"))
         whenever(sessionDatabase.getAllTopic()).doReturn(Flowable.just(topics))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())
@@ -79,6 +84,7 @@ class SessionsDataRepositoryTest {
         whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(sessions))
         whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(speakers))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())
@@ -94,12 +100,47 @@ class SessionsDataRepositoryTest {
         verify(sessionDatabase).getAllSessions()
     }
 
+    @Test fun sessionFeedbacks() {
+        val sessionEntities = createDummySessionWithSpeakersEntities()
+        val speakers = createDummySpeakerEntities()
+        val sessionFeedbacks = createDummySessionFeedbackEntities()
+
+        whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(sessionEntities))
+        whenever(sessionDatabase.getAllSessionFeedback()).doReturn(Flowable.just(sessionFeedbacks))
+        whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(speakers))
+        val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
+                sessionDatabase,
+                favoriteDatabase,
+                TestSchedulerProvider())
+
+        val sessions = listOf(
+                sessionEntities[0].toSession(speakers, emptyList(), LocalDate.of(1, 1, 1)),
+                sessionEntities[1].toSession(speakers, emptyList(), LocalDate.of(1, 1, 1)))
+        sessionDataRepository.sessionFeedbacks
+                .test()
+                .assertNoErrors()
+                .assertValue(
+                        sessionFeedbacks.map { sessionFeedback ->
+                            sessionFeedback.toSessionFeedback().also {
+                                sessions.forEach { session ->
+                                    if (it.sessionId == session.id) {
+                                        it.copy(sessionTitle = session.title)
+                                    }
+                                }
+                            }
+                        })
+
+        verify(sessionDatabase).getAllSessionFeedback()
+    }
+
     @Test fun search() {
         val sessions = createDummySessionWithSpeakersEntities()
         val speakers = createDummySpeakerEntities()
         whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(sessions))
         whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(speakers))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())
@@ -118,6 +159,7 @@ class SessionsDataRepositoryTest {
         whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(sessionEntities))
         whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(speakers))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())
@@ -145,6 +187,7 @@ class SessionsDataRepositoryTest {
         whenever(sessionDatabase.getAllSessions()).doReturn(Flowable.just(sessionEntities))
         whenever(sessionDatabase.getAllSpeaker()).doReturn(Flowable.just(speakers))
         val sessionDataRepository = SessionDataRepository(mock(),
+                mock(),
                 sessionDatabase,
                 favoriteDatabase,
                 TestSchedulerProvider())

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackViewModelTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/feedback/SessionsFeedbackViewModelTest.kt
@@ -1,0 +1,51 @@
+package io.github.droidkaigi.confsched2018.presentation.sessions.feedback
+
+import android.arch.lifecycle.Observer
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.whenever
+import io.github.droidkaigi.confsched2018.DUMMY_SESSION_ID1
+import io.github.droidkaigi.confsched2018.DUMMY_SESSION_ID2
+import io.github.droidkaigi.confsched2018.DUMMY_SESSION_TITLE1
+import io.github.droidkaigi.confsched2018.DUMMY_SESSION_TITLE2
+import io.github.droidkaigi.confsched2018.createDummySessionFeedback
+import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
+import io.github.droidkaigi.confsched2018.model.SessionFeedback
+import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.util.rx.TestSchedulerProvider
+import io.reactivex.Completable
+import io.reactivex.Flowable
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class SessionsFeedbackViewModelTest {
+    @Mock private val repository: SessionRepository = mock()
+
+    private lateinit var viewModel: SessionsFeedbackViewModel
+
+    @Before fun init() {
+        whenever(repository.refreshSessions()).doReturn(Completable.complete())
+    }
+
+    @Test fun init_Basic() {
+        val sessionFeedback_1 = createDummySessionFeedback(DUMMY_SESSION_ID1, DUMMY_SESSION_TITLE1)
+        val sessionFeedback_2 = createDummySessionFeedback(DUMMY_SESSION_ID2, DUMMY_SESSION_TITLE2)
+        val sessionFeedbackResults = listOf(sessionFeedback_1, sessionFeedback_2)
+        whenever(repository.sessionFeedbacks).doReturn(Flowable.just(sessionFeedbackResults))
+        viewModel = SessionsFeedbackViewModel(repository, TestSchedulerProvider())
+        val result: Observer<Result<SessionFeedback>> = mock()
+        viewModel.mutableSessionFeedback.observeForever(result)
+
+        viewModel.sessionId = sessionFeedback_1.sessionId
+        viewModel.sessionTitle = sessionFeedback_1.sessionTitle
+        viewModel.init()
+
+        verify(repository).sessionFeedbacks
+        verify(result).onChanged(Result.success(sessionFeedback_1))
+    }
+}

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSectionTest.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/presentation/sessions/item/DateSessionsSectionTest.kt
@@ -44,7 +44,7 @@ class DateSessionsSectionTest {
 
         @Test fun emptySessions() {
             assertItemCount(0)
-            section.updateSessions(emptyList(), {})
+            section.updateSessions(emptyList(), {}, {})
             assertItemCount(0)
         }
 
@@ -55,13 +55,13 @@ class DateSessionsSectionTest {
             sections[0] : DateHeaderItem()
             sections[1] : SpeechSessionItem()
              */
-            section.updateSessions(listOf(createDummySession()), {})
+            section.updateSessions(listOf(createDummySession()), {}, {})
             assertItemCount(2)
             assertItemInstanceOf(0, DateHeaderItem::class.java)
             assertItemInstanceOf(1, SpeechSessionItem::class.java)
 
             // re-update test
-            section.updateSessions(listOf(createDummySession()), {})
+            section.updateSessions(listOf(createDummySession()), {}, {})
             assertItemCount(2)
             assertItemInstanceOf(0, DateHeaderItem::class.java)
             assertItemInstanceOf(1, SpeechSessionItem::class.java)
@@ -74,7 +74,7 @@ class DateSessionsSectionTest {
              */
             section.updateSessions(listOf(
                     createDummySpecialSession(),
-                    createDummySession()), {})
+                    createDummySession()), {}, {})
             assertItemCount(3)
             assertItemInstanceOf(0, DateHeaderItem::class.java)
             assertItemInstanceOf(1, SpecialSessionItem::class.java)
@@ -87,7 +87,7 @@ class DateSessionsSectionTest {
 
         @Test fun emptySessions() {
             assertDateHeaderPosition(Date(), 0)
-            section.updateSessions(emptyList(), {})
+            section.updateSessions(emptyList(), {}, {})
             assertDateHeaderPosition(Date(), 0)
         }
 
@@ -108,7 +108,7 @@ class DateSessionsSectionTest {
                     createDummySession(startTime = 20000, endTime = 20000),
                     createDummySession(startTime = 20000, endTime = 20000),
                     createDummySession(startTime = 30000, endTime = 30000)
-            ), {})
+            ), {}, {})
 
             assertItemCount(8)
             assertDateHeaderPosition(Date(1000), 0)
@@ -128,7 +128,7 @@ class DateSessionsSectionTest {
 
         @Test fun emptySessions() {
             assertDateNumberOrNull(0, null)
-            section.updateSessions(emptyList(), {})
+            section.updateSessions(emptyList(), {}, {})
             assertDateNumberOrNull(0, null)
         }
 
@@ -148,7 +148,7 @@ class DateSessionsSectionTest {
                     createDummySession(dayNumber = 2, startTime = 20000, endTime = 20000),
                     createDummySession(dayNumber = 2, startTime = 20000, endTime = 20000),
                     createDummySession(dayNumber = 2, startTime = 20000, endTime = 20000)
-            ), {})
+            ), {}, {})
 
             assertItemCount(7)
             assertDateNumberOrNull(0, 1)

--- a/model/src/main/java/io/github/droidkaigi/confsched2018/model/SessionFeedback.kt
+++ b/model/src/main/java/io/github/droidkaigi/confsched2018/model/SessionFeedback.kt
@@ -2,12 +2,12 @@ package io.github.droidkaigi.confsched2018.model
 
 data class SessionFeedback(
         val sessionId: String,
-        var sessionTitle: String,
-        var totalEvaluation: Int,
-        var relevancy: Int,
-        var asExpected: Int,
-        var difficulty: Int,
-        var knowledgeable: Int,
-        var comment: String,
-        var submitted: Boolean
+        val sessionTitle: String,
+        val totalEvaluation: Int,
+        val relevancy: Int,
+        val asExpected: Int,
+        val difficulty: Int,
+        val knowledgeable: Int,
+        val comment: String,
+        val submitted: Boolean
 )

--- a/model/src/main/java/io/github/droidkaigi/confsched2018/model/SessionFeedback.kt
+++ b/model/src/main/java/io/github/droidkaigi/confsched2018/model/SessionFeedback.kt
@@ -2,12 +2,12 @@ package io.github.droidkaigi.confsched2018.model
 
 data class SessionFeedback(
         val sessionId: String,
-        val sessionTitle: String,
-        val totalEvaluation: Int,
-        val relevancy: Int,
-        val asExpected: Int,
-        val difficulty: Int,
-        val knowledgeable: Int,
-        val comment: String,
+        var sessionTitle: String,
+        var totalEvaluation: Int,
+        var relevancy: Int,
+        var asExpected: Int,
+        var difficulty: Int,
+        var knowledgeable: Int,
+        var comment: String,
         var submitted: Boolean
 )


### PR DESCRIPTION
## Issue
- related #40

## Overview (Required)
- Add SessionFeedback screen without design
    - if update sesseion feedback and close screen, save session feedback local db
    - if click submit button, send feedback to googleform

## Links
- 

## Screenshot
### save local db
Before | After | Note
:--: | :--: | :--:
no screen | <img src="https://user-images.githubusercontent.com/944185/35346227-054a817e-0175-11e8-90bf-287f8ec2b0cb.gif" width="300" />|<img src="https://user-images.githubusercontent.com/944185/35346425-8f3ad654-0175-11e8-84ab-51d641dbffd9.png" width="300" /> 


### send feedback to googleform
<img src="https://user-images.githubusercontent.com/944185/35346722-50e1a134-0176-11e8-9972-7820d0a31574.png" width="300" />



