### PR TITLE
Fix Firestore's offline get() problem

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.confsched2018.data.db
 
 import android.support.annotation.CheckResult
-import com.google.android.gms.tasks.Task
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.google.firebase.firestore.DocumentSnapshot
@@ -9,6 +8,7 @@ import com.google.firebase.firestore.EventListener
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
 import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.util.ext.toSingle
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Observable
@@ -177,9 +177,4 @@ class FavoriteFirestoreDatabase : FavoriteDatabase {
     companion object {
         private const val DEBUG: Boolean = false
     }
-}
-
-fun <R> Task<R>.toSingle() = Single.create<R> { emitter ->
-    this.addOnSuccessListener { emitter.onSuccess(it) }
-            .addOnFailureListener { emitter.onError(it) }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/FavoriteFirestoreDatabase.kt
@@ -169,3 +169,8 @@ class FavoriteFirestoreDatabase : FavoriteDatabase {
         private const val DEBUG: Boolean = false
     }
 }
+
+fun <R> Task<R>.toSingle() = Single.create<R> { emitter ->
+    this.addOnSuccessListener { emitter.onSuccess(it) }
+            .addOnFailureListener { emitter.onError(it) }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirebaseTaskExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirebaseTaskExt.kt
@@ -1,0 +1,15 @@
+package io.github.droidkaigi.confsched2018.util.ext
+
+import com.google.android.gms.tasks.Task
+import io.reactivex.Completable
+import io.reactivex.Single
+
+fun <R> Task<R>.toSingle() = Single.create<R> { emitter ->
+    this.addOnSuccessListener { emitter.onSuccess(it) }
+            .addOnFailureListener { emitter.onError(it) }
+}
+
+fun <R> Task<R>.toCompletable() = Completable.create { emitter ->
+    this.addOnSuccessListener { emitter.onComplete() }
+            .addOnFailureListener { emitter.onError(it) }
+}


### PR DESCRIPTION
## Issue
- close #277

## Overview (Required)
- When device is offline and document doesn't exist, Firestore's `get()` cause error and return nothing. Instead, I changed code to use `addSnapshotListener(...)`.
    - `FavoriteFirestoreDatabase::setupFavoritesDocument`
    - `FavoriteFirestoreDatabase::favorite`

## Links
- https://firebase.google.com/docs/firestore/manage-data/enable-offline#get_offline_data

