### PR TITLE
Fix confused scroll gesture in map fragment

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/map/MapFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/map/MapFragment.kt
@@ -56,7 +56,10 @@ class MapFragment : Fragment(), Injectable, OnMapReadyCallback {
     override fun onMapReady(map: GoogleMap?) {
         map?.run {
             val latLng = LatLng(placeLat, placeLang)
-            addMarker(MarkerOptions().position(latLng))
+            val marker = addMarker(MarkerOptions()
+                    .position(latLng)
+                    .title(context?.getString(R.string.map_place_name)))
+            marker.showInfoWindow()
 
             val cameraUpdate = CameraUpdateFactory.newLatLngZoom(latLng, 16f)
             moveCamera(cameraUpdate)

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -16,6 +16,7 @@
                 android:id="@+id/map_view"
                 android:layout_width="match_parent"
                 android:layout_height="270dp"
+                app:liteMode="true"
                 />
             <FrameLayout
                 android:id="@+id/place_view"


### PR DESCRIPTION
## Overview (Required)
Vertical scroll gesture in map fragment is confused with map and scrollview.
This PR is ..

- Enable lite-mode to map which means disable all gesture for map
- Show place info-window when shown this activity
- Also show "MapToolBar" which provides shortcut to launch map apps

## Links
- https://stackoverflow.com/a/31678235/3309589

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/401369/35437425-aa3a6148-02d5-11e8-8771-5be4c6c002ee.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/401369/35437439-b642a810-02d5-11e8-9053-61a73c9e772a.gif" width="300" />
