### PR TITLE
Add corner radius to button and Fix typo

### DIFF
--- a/app/src/main/res/drawable-v21/bg_go_to_questionnaire.xml
+++ b/app/src/main/res/drawable-v21/bg_go_to_questionnaire.xml
@@ -2,5 +2,5 @@
 <ripple
     xmlns:app="http://schemas.android.com/apk/res/android"
     app:color="@color/button_ripple">
-    <item app:drawable="@color/primary_dark" />
+    <item app:drawable="@drawable/shape_go_to_questionnaire" />
 </ripple>

--- a/app/src/main/res/drawable/bg_go_to_questionaire.xml
+++ b/app/src/main/res/drawable/bg_go_to_questionaire.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/primary_dark" />
-</selector>

--- a/app/src/main/res/drawable/bg_go_to_questionnaire.xml
+++ b/app/src/main/res/drawable/bg_go_to_questionnaire.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:shape="rectangle">
+            <solid android:color="@color/primary_dark" />
+            <corners android:radius="2dp" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/shape_go_to_questionnaire.xml
+++ b/app/src/main/res/drawable/shape_go_to_questionnaire.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary_dark" />
+    <corners android:radius="2dp" />
+</shape>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -90,7 +90,7 @@
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textColor">@color/app_bar_text_color</item>
-        <item name="android:background">@drawable/bg_go_to_questionaire</item>
+        <item name="android:background">@drawable/bg_go_to_questionnaire</item>
         <item name="android:gravity">center</item>
         <item name="android:paddingLeft">8dp</item>
         <item name="android:paddingTop">11dp</item>


### PR DESCRIPTION
## Issue
- close #486 

## Overview (Required)
- Add 2dp corner radius to GoToQuestionnaire Button
- Fix typo (Questionaire ➡️  Questionnaire)

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/26833834/35435287-7aedc996-02cd-11e8-8228-8de560599601.png" width="300" /> | <img src="https://user-images.githubusercontent.com/26833834/35439155-d8197656-02dc-11e8-8394-450f348ade44.png" width="300" />