### PR TITLE
Fix warning: Staff to Staffs (plurals)

### DIFF
--- a/app/src/main/res/layout/item_staff_header.xml
+++ b/app/src/main/res/layout/item_staff_header.xml
@@ -22,7 +22,7 @@
             android:layout_marginStart="72dp"
             android:layout_marginTop="36dp"
             android:gravity="center_horizontal"
-            android:text="@{@string/staff_header(staffCount)}"
+            android:text="@{@plurals/staff_header(staffCount, staffCount)}"
             android:textSize="24sp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -96,7 +96,9 @@
     <!-- Staff -->
     <string name="staff">スタッフ</string>
     <string name="staff_avatar">スタッフのプロフィール画像</string>
-    <string name="staff_header">%d 人のスタッフ</string>
+    <plurals name="staff_header">
+        <item quantity="other">%d 人のスタッフ</item>
+    </plurals>
 
     <!-- Notification -->
     <string name="notification_title">%1$s がもうすぐ始まります。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -110,7 +110,10 @@
     <!-- Staff -->
     <string name="staff">Staff</string>
     <string name="staff_avatar">staff avatar</string>
-    <string name="staff_header">%d Staff</string>
+    <plurals name="staff_header">
+        <item quantity="one">%d Staff</item>
+        <item quantity="other">%d Staffs</item>
+    </plurals>
 
     <!-- Notification -->
     <string name="notification_title">%1$s will start soon</string>


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Fix warning : Formatting %d followed by words ("Staff"): This should probably be a plural rather than a string

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
