### PR TITLE
Close keyboard when drawer open

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -1,6 +1,5 @@
 package io.github.droidkaigi.confsched2018.presentation.common.menu
 
-import android.content.Context
 import android.support.annotation.IdRes
 import android.support.design.widget.NavigationView
 import android.support.v4.view.GravityCompat
@@ -10,7 +9,6 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.SearchView
 import android.support.v7.widget.Toolbar
 import android.view.View
-import android.view.inputmethod.InputMethodManager
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.presentation.MainActivity
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
@@ -44,14 +42,11 @@ class DrawerMenu @Inject constructor(
                     toolbar,
                     R.string.nav_content_description_drawer_open,
                     R.string.nav_content_description_drawer_close
-            ){
-                override fun onDrawerOpened(drawerView: View) {
-                    super.onDrawerOpened(drawerView)
-                    val temp = activity.currentFocus
-                    if(temp is SearchView.SearchAutoComplete ) {
-                        val imm = drawerView.context.getSystemService(Context.INPUT_METHOD_SERVICE) as
-                                InputMethodManager
-                        imm.hideSoftInputFromWindow(drawerView.windowToken, 0)
+            ) {
+                override fun onDrawerSlide(drawerView: View, slideOffset: Float) {
+                    super.onDrawerSlide(drawerView, slideOffset)
+                    if (activity.currentFocus is SearchView.SearchAutoComplete) {
+                        drawerView.requestFocus()
                     }
                 }
             }.also {
@@ -82,7 +77,6 @@ class DrawerMenu @Inject constructor(
                     navigationView.setCheckedItem(it.menuId)
                 }
                 ?: DrawerNavigationItem.OTHER
-
     }
 
     fun closeDrawerIfNeeded(): Boolean {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/menu/DrawerMenu.kt
@@ -1,12 +1,16 @@
 package io.github.droidkaigi.confsched2018.presentation.common.menu
 
+import android.content.Context
 import android.support.annotation.IdRes
 import android.support.design.widget.NavigationView
 import android.support.v4.view.GravityCompat
 import android.support.v4.widget.DrawerLayout
 import android.support.v7.app.ActionBarDrawerToggle
 import android.support.v7.app.AppCompatActivity
+import android.support.v7.widget.SearchView
 import android.support.v7.widget.Toolbar
+import android.view.View
+import android.view.inputmethod.InputMethodManager
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.presentation.MainActivity
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
@@ -34,13 +38,23 @@ class DrawerMenu @Inject constructor(
     ) {
         this.drawerLayout = drawerLayout
         if (actionBarDrawerSync) {
-            ActionBarDrawerToggle(
+            object : ActionBarDrawerToggle(
                     activity,
                     drawerLayout,
                     toolbar,
                     R.string.nav_content_description_drawer_open,
                     R.string.nav_content_description_drawer_close
-            ).also {
+            ){
+                override fun onDrawerOpened(drawerView: View) {
+                    super.onDrawerOpened(drawerView)
+                    val temp = activity.currentFocus
+                    if(temp is SearchView.SearchAutoComplete ) {
+                        val imm = drawerView.context.getSystemService(Context.INPUT_METHOD_SERVICE) as
+                                InputMethodManager
+                        imm.hideSoftInputFromWindow(drawerView.windowToken, 0)
+                    }
+                }
+            }.also {
                 drawerLayout.addDrawerListener(it)
             }.apply {
                 isDrawerIndicatorEnabled = true
@@ -68,6 +82,7 @@ class DrawerMenu @Inject constructor(
                     navigationView.setCheckedItem(it.menuId)
                 }
                 ?: DrawerNavigationItem.OTHER
+
     }
 
     fun closeDrawerIfNeeded(): Boolean {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -16,7 +16,6 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
@@ -157,9 +156,7 @@ class SearchFragment : Fragment(), Injectable {
 
         searchView.setOnQueryTextFocusChangeListener { view, hasFocus ->
             if (!hasFocus) {
-                val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as
-                        InputMethodManager
-                imm.hideSoftInputFromWindow(view.windowToken, 0)
+                searchView.isIconified = true
             }
         }
     }


### PR DESCRIPTION
## Issue
- close #349 

## Overview (Required)
- Close keyboard when drawer is slided.
- In order to close keyboard only once, drawer requests focus when current focus is on `SearchView.SearchAutoComplete`
- Changed closing keyboard method to `isIconified = true` because this method closed keyboard and changed icon to magnified grass 

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/21967922/35479311-6cd7c724-0437-11e8-9946-791768ad1ca6.gif"> | <img src="https://user-images.githubusercontent.com/21967922/35479314-80563a10-0437-11e8-9375-6f682cc63a28.gif">

