### PR TITLE
Refactor around Firestore+Rx

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/FeedFirestoreApi.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/FeedFirestoreApi.kt
@@ -3,7 +3,7 @@ package io.github.droidkaigi.confsched2018.data.api
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import io.github.droidkaigi.confsched2018.data.api.response.Post
-import io.github.droidkaigi.confsched2018.util.ext.rx
+import io.github.droidkaigi.confsched2018.util.ext.observesSnapshot
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import timber.log.Timber
@@ -15,8 +15,8 @@ class FeedFirestoreApi : FeedApi {
         FirebaseFirestore.getInstance()
                 .collection("posts")
                 .whereEqualTo("published", true)
-                .orderBy("date", Query.Direction.DESCENDING).rx
-                .observe()
+                .orderBy("date", Query.Direction.DESCENDING)
+                .observesSnapshot()
                 .map { it.map { it.toObject(Post::class.java) } }
                 .toFlowable(BackpressureStrategy.DROP)
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/FeedFirestoreApi.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/FeedFirestoreApi.kt
@@ -1,52 +1,25 @@
 package io.github.droidkaigi.confsched2018.data.api
 
-import com.google.firebase.firestore.EventListener
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.Query
 import io.github.droidkaigi.confsched2018.data.api.response.Post
+import io.github.droidkaigi.confsched2018.util.ext.rx
 import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
-import io.reactivex.FlowableEmitter
-import io.reactivex.android.MainThreadDisposable
 import timber.log.Timber
 
 class FeedFirestoreApi : FeedApi {
-    override val feeds: Flowable<List<Post>> =
-            Flowable.create<List<Post>>({ e: FlowableEmitter<List<Post>> ->
-                if (e.isCancelled) {
-                    e.onComplete()
-                }
-                if (DEBUG) Timber.d("Firestore:getFeeds")
-                val database = FirebaseFirestore.getInstance()
-                val postCollection = database.collection("posts")
-                        .whereEqualTo("published", true)
-                        .orderBy("date", Query.Direction.DESCENDING)
-                val removable =
-                        postCollection.addSnapshotListener(EventListener { snapshot, exception ->
-                            if (exception != null) {
-                                if (DEBUG) Timber.d("Firestore:getFeeds onChange exception")
-                                e.onError(exception)
-                                return@EventListener
-                            }
-                            if (!snapshot.isEmpty) {
-                                if (DEBUG) Timber.d("Firestore:getFeeds onChange")
-                                val documents = snapshot.documents
-                                val posts = documents.map { it.toObject(Post::class.java) }
-                                if (DEBUG) Timber.d("Firestore:getFeeds %s", posts.toString())
-                                e.onNext(posts)
-                            } else {
-                                if (DEBUG) Timber.d("Firestore:getFeeds return empty")
-                                e.onNext(listOf())
-                            }
-                        })
+    override val feeds: Flowable<List<Post>> = Flowable.defer {
+        if (DEBUG) Timber.d("Firestore:getFeeds")
 
-                e.setDisposable(object : MainThreadDisposable() {
-                    override fun onDispose() {
-                        if (DEBUG) Timber.d("Firestore:getFeeds dispose")
-                        removable.remove()
-                    }
-                })
-            }, BackpressureStrategy.DROP)
+        FirebaseFirestore.getInstance()
+                .collection("posts")
+                .whereEqualTo("published", true)
+                .orderBy("date", Query.Direction.DESCENDING).rx
+                .observe()
+                .map { it.map { it.toObject(Post::class.java) } }
+                .toFlowable(BackpressureStrategy.DROP)
+    }
 
     companion object {
         private const val DEBUG: Boolean = false

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirebaseAuth.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirebaseAuth.kt
@@ -1,0 +1,29 @@
+package io.github.droidkaigi.confsched2018.util
+
+import android.support.annotation.CheckResult
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import io.github.droidkaigi.confsched2018.util.ext.toSingle
+import io.reactivex.Single
+import timber.log.Timber
+
+object RxFirebaseAuth {
+
+    @CheckResult
+    fun getCurrentUser(): Single<FirebaseUser> = Single.defer {
+        val auth = FirebaseAuth.getInstance()
+        val currentUser = auth.currentUser
+        if (currentUser != null) {
+            if (DEBUG) Timber.d("Firestore:Get cached user")
+            return@defer Single.just(currentUser)
+        }
+        auth.signInAnonymously()
+                .toSingle()
+                .map { it.user }
+                .doOnSuccess { if (DEBUG) Timber.d("Firestore:Sign in Anonymously") }
+                .doOnError { if (DEBUG) Timber.d("Firestore:Sign in error") }
+    }
+
+    private const val DEBUG: Boolean = false
+
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirebaseAuth.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirebaseAuth.kt
@@ -8,7 +8,6 @@ import io.reactivex.Single
 import timber.log.Timber
 
 object RxFirebaseAuth {
-
     @CheckResult
     fun getCurrentUser(): Single<FirebaseUser> = Single.defer {
         val auth = FirebaseAuth.getInstance()
@@ -25,5 +24,4 @@ object RxFirebaseAuth {
     }
 
     private const val DEBUG: Boolean = false
-
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirestore.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/RxFirestore.kt
@@ -1,0 +1,64 @@
+package io.github.droidkaigi.confsched2018.util
+
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import io.github.droidkaigi.confsched2018.util.ext.toCompletable
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+
+object RxFirestore {
+
+    fun observeDocumentSnapshot(ref: DocumentReference): Observable<DocumentSnapshot> {
+        return Observable.create<DocumentSnapshot> { emitter ->
+            val listener = ref.addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    emitter.onError(error)
+                } else {
+                    emitter.onNext(snapshot)
+                }
+            }
+            emitter.setCancellable { listener.remove() }
+        }
+    }
+
+    fun getDocumentSnapshot(ref: DocumentReference): Single<DocumentSnapshot> {
+        return observeDocumentSnapshot(ref).take(1).singleOrError()
+    }
+
+    fun setDocument(ref: DocumentReference, value: Any): Completable {
+        return Completable.defer { ref.set(value).toCompletable() }
+    }
+
+    fun deleteDocument(ref: DocumentReference): Completable {
+        return Completable.defer { ref.delete().toCompletable() }
+    }
+
+    fun addDocumentToCollection(ref: CollectionReference, value: Any): Completable {
+        return Completable.defer { ref.add(value).toCompletable() }
+    }
+
+    fun observeQuerySnapshot(ref: Query): Observable<QuerySnapshot> {
+        return Observable.create { emitter ->
+            val listener = ref.addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    emitter.tryOnError(error)
+                } else {
+                    emitter.onNext(snapshot)
+                }
+            }
+            emitter.setCancellable { listener.remove() }
+        }
+    }
+
+    fun getQuerySnapshot(ref: Query): Single<QuerySnapshot> {
+        return observeQuerySnapshot(ref).take(1).singleOrError()
+    }
+
+    fun isQuerySnapshotEmpty(ref: Query): Single<Boolean> {
+        return getQuerySnapshot(ref).map { it.isEmpty }
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
@@ -2,113 +2,16 @@ package io.github.droidkaigi.confsched2018.util.ext
 
 import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.DocumentReference
-import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.Query
-import com.google.firebase.firestore.QuerySnapshot
-import io.reactivex.Completable
-import io.reactivex.Observable
-import io.reactivex.Single
+import io.github.droidkaigi.confsched2018.util.RxFirestore
 
-interface RxDocumentReference {
-    fun observe(): Observable<DocumentSnapshot>
-    fun get(): Single<DocumentSnapshot>
-    fun exists(): Single<Boolean>
-    fun set(value: Any): Completable
-    fun delete(): Completable
-}
+fun DocumentReference.observesSnapshot() = RxFirestore.observeDocumentSnapshot(this)
+fun DocumentReference.getsSnapshot() = RxFirestore.getDocumentSnapshot(this)
+fun DocumentReference.sets(value: Any) = RxFirestore.setDocument(this, value)
+fun DocumentReference.deletes() = RxFirestore.deleteDocument(this)
 
-interface RxCollectionReference {
-    fun observe(): Observable<QuerySnapshot>
-    fun get(): Single<QuerySnapshot>
-    fun isEmpty(): Single<Boolean>
-    fun add(value: Any): Completable
-}
+fun CollectionReference.adds(value: Any) = RxFirestore.addDocumentToCollection(this, value)
 
-interface RxQuery {
-    fun observe(): Observable<QuerySnapshot>
-    fun get(): Single<QuerySnapshot>
-    fun isEmpty(): Single<Boolean>
-}
-
-val DocumentReference.rx: RxDocumentReference
-    get() {
-        val ref = this // hack to access outer class
-        return object : RxDocumentReference {
-            override fun observe(): Observable<DocumentSnapshot> {
-                return Observable.create<DocumentSnapshot> { emitter ->
-                    val listener = addSnapshotListener { snapshot, error ->
-                        if (error != null) {
-                            emitter.onError(error)
-                        } else {
-                            emitter.onNext(snapshot)
-                        }
-                    }
-                    emitter.setCancellable { listener.remove() }
-                }
-            }
-
-            override fun get(): Single<DocumentSnapshot> {
-                return observe().take(1).singleOrError()
-            }
-
-            override fun exists(): Single<Boolean> {
-                return get().map { it.exists() }
-            }
-
-            override fun set(value: Any): Completable {
-                return Completable.defer { ref.set(value).toCompletable() }
-            }
-
-            override fun delete(): Completable {
-                return Completable.defer { ref.delete().toCompletable() }
-            }
-        }
-    }
-
-val CollectionReference.rx: RxCollectionReference
-    get() {
-        val ref = this // hack to access outer class
-        return object : RxCollectionReference {
-            override fun observe(): Observable<QuerySnapshot> {
-                return (ref as Query).rx.observe()
-            }
-
-            override fun get(): Single<QuerySnapshot> {
-                return (ref as Query).rx.get()
-            }
-
-            override fun isEmpty(): Single<Boolean> {
-                return (ref as Query).rx.isEmpty()
-            }
-
-            override fun add(value: Any): Completable {
-                return Completable.defer { ref.add(value).toCompletable() }
-            }
-        }
-    }
-
-val Query.rx: RxQuery
-    get() {
-        return object : RxQuery {
-            override fun observe(): Observable<QuerySnapshot> {
-                return Observable.create { emitter ->
-                    val listener = addSnapshotListener { snapshot, error ->
-                        if (error != null) {
-                            emitter.tryOnError(error)
-                        } else {
-                            emitter.onNext(snapshot)
-                        }
-                    }
-                    emitter.setCancellable { listener.remove() }
-                }
-            }
-
-            override fun get(): Single<QuerySnapshot> {
-                return observe().take(1).singleOrError()
-            }
-
-            override fun isEmpty(): Single<Boolean> {
-                return get().map { it.isEmpty }
-            }
-        }
-    }
+fun Query.observesSnapshot() = RxFirestore.observeQuerySnapshot(this)
+fun Query.getsSnapshot() = RxFirestore.getQuerySnapshot(this)
+fun Query.isEmpty() = RxFirestore.isQuerySnapshotEmpty(this)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
@@ -33,7 +33,7 @@ interface RxQuery {
 val DocumentReference.rx: RxDocumentReference
     get() {
         val ref = this // hack to access outer class
-        return object: RxDocumentReference {
+        return object : RxDocumentReference {
             override fun observe(): Observable<DocumentSnapshot> {
                 return Observable.create<DocumentSnapshot> { emitter ->
                     val listener = addSnapshotListener { snapshot, error ->
@@ -68,7 +68,7 @@ val DocumentReference.rx: RxDocumentReference
 val CollectionReference.rx: RxCollectionReference
     get() {
         val ref = this // hack to access outer class
-        return object: RxCollectionReference {
+        return object : RxCollectionReference {
             override fun observe(): Observable<QuerySnapshot> {
                 return (ref as Query).rx.observe()
             }
@@ -89,7 +89,7 @@ val CollectionReference.rx: RxCollectionReference
 
 val Query.rx: RxQuery
     get() {
-        return object: RxQuery {
+        return object : RxQuery {
             override fun observe(): Observable<QuerySnapshot> {
                 return Observable.create { emitter ->
                     val listener = addSnapshotListener { snapshot, error ->

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/FirestoreRxExt.kt
@@ -1,0 +1,114 @@
+package io.github.droidkaigi.confsched2018.util.ext
+
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import io.reactivex.Completable
+import io.reactivex.Observable
+import io.reactivex.Single
+
+interface RxDocumentReference {
+    fun observe(): Observable<DocumentSnapshot>
+    fun get(): Single<DocumentSnapshot>
+    fun exists(): Single<Boolean>
+    fun set(value: Any): Completable
+    fun delete(): Completable
+}
+
+interface RxCollectionReference {
+    fun observe(): Observable<QuerySnapshot>
+    fun get(): Single<QuerySnapshot>
+    fun isEmpty(): Single<Boolean>
+    fun add(value: Any): Completable
+}
+
+interface RxQuery {
+    fun observe(): Observable<QuerySnapshot>
+    fun get(): Single<QuerySnapshot>
+    fun isEmpty(): Single<Boolean>
+}
+
+val DocumentReference.rx: RxDocumentReference
+    get() {
+        val ref = this // hack to access outer class
+        return object: RxDocumentReference {
+            override fun observe(): Observable<DocumentSnapshot> {
+                return Observable.create<DocumentSnapshot> { emitter ->
+                    val listener = addSnapshotListener { snapshot, error ->
+                        if (error != null) {
+                            emitter.onError(error)
+                        } else {
+                            emitter.onNext(snapshot)
+                        }
+                    }
+                    emitter.setCancellable { listener.remove() }
+                }
+            }
+
+            override fun get(): Single<DocumentSnapshot> {
+                return observe().take(1).singleOrError()
+            }
+
+            override fun exists(): Single<Boolean> {
+                return get().map { it.exists() }
+            }
+
+            override fun set(value: Any): Completable {
+                return Completable.defer { ref.set(value).toCompletable() }
+            }
+
+            override fun delete(): Completable {
+                return Completable.defer { ref.delete().toCompletable() }
+            }
+        }
+    }
+
+val CollectionReference.rx: RxCollectionReference
+    get() {
+        val ref = this // hack to access outer class
+        return object: RxCollectionReference {
+            override fun observe(): Observable<QuerySnapshot> {
+                return (ref as Query).rx.observe()
+            }
+
+            override fun get(): Single<QuerySnapshot> {
+                return (ref as Query).rx.get()
+            }
+
+            override fun isEmpty(): Single<Boolean> {
+                return (ref as Query).rx.isEmpty()
+            }
+
+            override fun add(value: Any): Completable {
+                return Completable.defer { ref.add(value).toCompletable() }
+            }
+        }
+    }
+
+val Query.rx: RxQuery
+    get() {
+        return object: RxQuery {
+            override fun observe(): Observable<QuerySnapshot> {
+                return Observable.create { emitter ->
+                    val listener = addSnapshotListener { snapshot, error ->
+                        if (error != null) {
+                            emitter.tryOnError(error)
+                        } else {
+                            emitter.onNext(snapshot)
+                        }
+                    }
+                    emitter.setCancellable { listener.remove() }
+                }
+            }
+
+            override fun get(): Single<QuerySnapshot> {
+                return observe().take(1).singleOrError()
+            }
+
+            override fun isEmpty(): Single<Boolean> {
+                return get().map { it.isEmpty }
+            }
+        }
+    }


### PR DESCRIPTION
## Overview (Required)
- Refactor codes around Firestore by implementing Rx wrapper.

### Purpose
The purpose of this PR is to make code short and clean.
The logic of original code is not changed.

### Benefit

The code for converting Firestore events to Rx is split by these wrapper.
We can concentrate on business logic in model code.

### Added

- FirestoreRxExt
    - DocumentReference.rx
    - CollectionReference.rx
    - Query.rx
- RxFirebaseAuth [Singleton]
    - getCurrentUser

`hogehoge.rx` is inspired by RxSwift! 😄 

### Changed

- FeedFirestoreApi
- FavoriteFirestoreDatabase