### PR TITLE
changed to not use isIconified when query is not empty

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -14,11 +14,13 @@ import android.support.v4.app.FragmentStatePagerAdapter
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SearchView
 import android.support.v7.widget.SimpleItemAnimator
+import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import android.widget.TextView
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
@@ -182,7 +184,13 @@ class SearchFragment : Fragment(), Injectable {
 
         searchView.setOnQueryTextFocusChangeListener { view, hasFocus ->
             if (!hasFocus) {
-                searchView.isIconified = true
+                if (TextUtils.isEmpty(searchView.query)) {
+                    searchView.isIconified = true
+                } else {
+                    val imm = view.context.getSystemService(Context.INPUT_METHOD_SERVICE) as
+                            InputMethodManager
+                    imm.hideSoftInputFromWindow(view.windowToken, 0)
+                }
             }
         }
     }


### PR DESCRIPTION
## Issue
- close #503 

## Overview (Required)
- fixed search did not work because of SearchView is iconified when lost focus
- if query is empty, set iconified as true
- if query is not empty, just hide keyboard

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/21967922/35482017-3a4b010a-0472-11e8-917c-b141c7e4b971.gif" width="300" /> | <img src="https://user-images.githubusercontent.com/21967922/35482056-ba33fb7e-0472-11e8-9cd6-e3bd51f28928.gif" width="300" />
