### PR TITLE
fix: FireBaseAnalytics.setCurrentScreen() on Fragment may not be called

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/FragmentStateNullablePagerAdapter.java
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/FragmentStateNullablePagerAdapter.java
@@ -1,0 +1,23 @@
+package io.github.droidkaigi.confsched2018.presentation;
+
+import android.support.annotation.Nullable;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentStatePagerAdapter;
+import android.view.ViewGroup;
+
+/**
+ * memo:
+ * FragmentStateNullablePagerAdapter needs to be written in Kotlin.
+ * cuz, setPrimaryItem signature is #setPrimaryItem(@NonNull ViewGroup, int, @NonNull Object),
+ * but Object come in null, so kotlin occurs NPE crash
+ */
+public abstract class FragmentStateNullablePagerAdapter extends FragmentStatePagerAdapter {
+
+    public FragmentStateNullablePagerAdapter(FragmentManager fm) {
+        super(fm);
+    }
+
+    public void setPrimaryItem(ViewGroup container, int position, @Nullable Object object) {
+        super.setPrimaryItem(container, position, object);
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -43,6 +43,7 @@ import io.github.droidkaigi.confsched2018.util.ext.toGone
 import io.github.droidkaigi.confsched2018.util.ext.toVisible
 import timber.log.Timber
 import javax.inject.Inject
+import kotlin.properties.Delegates
 
 class SearchFragment : Fragment(), Injectable {
     private lateinit var binding: FragmentSearchBinding
@@ -211,8 +212,12 @@ class SearchBeforeViewPagerAdapter(
         fragmentManager: FragmentManager
 ) : FragmentStateNullablePagerAdapter(fragmentManager) {
 
-    private var currentFragment: Fragment? = null
     private val fireBaseAnalytics = FirebaseAnalytics.getInstance(activity)
+    private var currentFragment by Delegates.observable<Fragment?>(null) { _, old, new ->
+        if (old != new && new != null) {
+            fireBaseAnalytics.setCurrentScreen(activity, null, new::class.java.simpleName)
+        }
+    }
 
     enum class Tab(@StringRes val title: Int) {
         Session(R.string.search_before_tab_session),
@@ -236,9 +241,6 @@ class SearchBeforeViewPagerAdapter(
 
     override fun setPrimaryItem(container: ViewGroup, position: Int, o: Any?) {
         super.setPrimaryItem(container, position, o)
-        (o as? Fragment)?.takeIf { currentFragment != it }?.let { newFragment ->
-            fireBaseAnalytics.setCurrentScreen(activity, null, newFragment::class.java.simpleName)
-            currentFragment = newFragment
-        }
+        currentFragment = o as? Fragment
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSessionsFragment.kt
@@ -7,7 +7,6 @@ import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
 import io.github.droidkaigi.confsched2018.databinding.FragmentSearchSessionsBinding
@@ -24,7 +23,6 @@ import javax.inject.Inject
 
 class SearchSessionsFragment : Fragment(), Injectable {
 
-    private var fireBaseAnalytics: FirebaseAnalytics? = null
     private lateinit var binding: FragmentSearchSessionsBinding
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
@@ -66,18 +64,6 @@ class SearchSessionsFragment : Fragment(), Injectable {
                 }
             }
         })
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(context)
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser) {
-            fireBaseAnalytics?.setCurrentScreen(activity!!, null, this::class.java.simpleName)
-        }
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSpeakersFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSpeakersFragment.kt
@@ -23,7 +23,6 @@ import javax.inject.Inject
 
 class SearchSpeakersFragment : Fragment(), Injectable {
 
-    private var fireBaseAnalytics: FirebaseAnalytics? = null
     private lateinit var binding: FragmentSearchSpeakersBinding
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
@@ -58,18 +57,6 @@ class SearchSpeakersFragment : Fragment(), Injectable {
                 }
             }
         })
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(context)
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser) {
-            fireBaseAnalytics?.setCurrentScreen(activity!!, null, this::class.java.simpleName)
-        }
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchTopicsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchTopicsFragment.kt
@@ -24,7 +24,6 @@ import javax.inject.Inject
 
 class SearchTopicsFragment : Fragment(), Injectable {
 
-    private var fireBaseAnalytics: FirebaseAnalytics? = null
     private lateinit var binding: FragmentSearchTopicsBinding
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
 
@@ -59,18 +58,6 @@ class SearchTopicsFragment : Fragment(), Injectable {
                 }
             }
         })
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(context)
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser) {
-            fireBaseAnalytics?.setCurrentScreen(activity!!, null, this::class.java.simpleName)
-        }
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -12,7 +12,6 @@ import android.support.v7.widget.SimpleItemAnimator
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.google.firebase.analytics.FirebaseAnalytics
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
 import io.github.droidkaigi.confsched2018.R
@@ -21,9 +20,9 @@ import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.DateSessionsSection
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
-import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
@@ -40,7 +39,6 @@ import javax.inject.Inject
 
 class AllSessionsFragment : Fragment(), Injectable, CurrentSessionScroller {
 
-    private var fireBaseAnalytics: FirebaseAnalytics? = null
     private lateinit var binding: FragmentAllSessionsBinding
 
     private val sessionsSection = DateSessionsSection()
@@ -67,7 +65,6 @@ class AllSessionsFragment : Fragment(), Injectable, CurrentSessionScroller {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(context)
         setupRecyclerView()
 
         val progressTimeLatch = ProgressTimeLatch {
@@ -93,13 +90,6 @@ class AllSessionsFragment : Fragment(), Injectable, CurrentSessionScroller {
             if (it != true) return@observe
             scrollToCurrentSession()
         })
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser) {
-            fireBaseAnalytics?.setCurrentScreen(activity!!, null, this::class.java.simpleName)
-        }
     }
 
     override fun scrollToCurrentSession() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -41,7 +41,6 @@ import javax.inject.Inject
 
 class RoomSessionsFragment : Fragment(), Injectable, CurrentSessionScroller {
 
-    private var fireBaseAnalytics: FirebaseAnalytics? = null
     private lateinit var binding: FragmentRoomSessionsBinding
     private lateinit var roomName: String
 
@@ -100,19 +99,6 @@ class RoomSessionsFragment : Fragment(), Injectable, CurrentSessionScroller {
             if (it != true) return@observe
             scrollToCurrentSession()
         })
-    }
-
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-        fireBaseAnalytics = FirebaseAnalytics.getInstance(context)
-    }
-
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        if (isVisibleToUser) {
-            fireBaseAnalytics?.setCurrentScreen(activity!!, null, this::class.java
-                    .simpleName + sessionsViewModel.roomName)
-        }
     }
 
     override fun scrollToCurrentSession() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -40,10 +40,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        sessionsViewPagerAdapter = SessionsViewPagerAdapter(
-                childFragmentManager,
-                FirebaseAnalytics.getInstance(context)
-        )
+        sessionsViewPagerAdapter = SessionsViewPagerAdapter(childFragmentManager, activity!!)
         binding.sessionsViewPager.adapter = sessionsViewPagerAdapter
 
         sessionsViewModel = ViewModelProviders
@@ -107,10 +104,11 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
 
 class SessionsViewPagerAdapter(
         fragmentManager: FragmentManager,
-        private val fireBaseAnalytics: FirebaseAnalytics
+        private val activity: Activity
 ) : FragmentStateNullablePagerAdapter(fragmentManager) {
 
     private var currentFragment: Fragment? = null
+    private val fireBaseAnalytics = FirebaseAnalytics.getInstance(activity)
 
     private val tabs = arrayListOf<Tab>()
     private var roomTabs = mutableListOf<Tab.RoomTab>()
@@ -146,17 +144,14 @@ class SessionsViewPagerAdapter(
     override fun setPrimaryItem(container: ViewGroup, position: Int, o: Any?) {
         super.setPrimaryItem(container, position, o)
         (o as? Fragment)?.takeIf { currentFragment != it }?.let { newFragment ->
-            val activity = container.context as Activity
-            when (newFragment) {
-                is AllSessionsFragment -> {
-                    fireBaseAnalytics.setCurrentScreen(activity, null, newFragment::class.java.simpleName)
-                }
+            val key = when (newFragment) {
                 is RoomSessionsFragment -> {
                     val tab = tabs[position] as Tab.RoomTab
-                    fireBaseAnalytics.setCurrentScreen(activity,
-                            null, newFragment::class.java.simpleName + tab.room)
+                    newFragment::class.java.simpleName + tab.room
                 }
+                else -> newFragment::class.java.simpleName
             }
+            fireBaseAnalytics.setCurrentScreen(activity, null, key)
             currentFragment = newFragment
         }
     }


### PR DESCRIPTION
## Issue
- close #500 

## Overview (Required)

setCurrentScreen isn't called from Fragment of ViewPager. cuz fireBaseAnalytics instance doesn't create at setUserVisibleHint.(only first fragment into ViewPager)
So, extends setPrimaryItem and send fireBaseAnalytics event in setPrimaryItem method. setPrimaryItem method, Fragment guarantee to be active.

and it's pr including small dirty hack(FragmentStateNullablePagerAdapter.java). 
base PagerAdapter class has `PagerAdapter#setPrimaryItem(@NonNull ViewGroup, int, @NonNull Object)`  method, but actually `PagerAdapter#setPrimaryItem(@NonNull ViewGroup, int, @Nullable Object)`. so i create FragmentStateNullablePagerAdapter class and override setPrimaryItem method with `@Nullable`.

---

(日本語でも)

setCurrentScreenがViewPager内のFramgentから呼ばれていませんでした。setUserVisibleHintメソッドが呼ばれたタイミングでfireBaseAnalyticsが生成されていないことがあったためです。なので、setPrimaryItemメソッド内でfireBaseAnalyticsイベントを呼び出すことにしました。


## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
