### PR TITLE
#514 Made selectable the session title and the session detail text.

### DIFF
--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -69,6 +69,7 @@
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             android:layout_marginStart="16dp"
+                            android:textIsSelectable="true"
                             android:text="@{session.title}"
                             android:textColor="@color/app_bar_text_color"
                             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -245,6 +245,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="16dp"
+                        android:textIsSelectable="true"
                         android:layout_marginEnd="16dp"
                         android:layout_marginStart="16dp"
                         android:layout_marginTop="24dp"


### PR DESCRIPTION
## Issue
- close #514 

## Overview (Required)
- I made selectable the session title and the session detail text.

## Links
- http://y-anz-m.blogspot.jp/2012/10/androidtextview.html

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8677433/35483703-93428df8-0488-11e8-99bf-8bb7bb2aae08.png" width="300" /> | <image src="https://user-images.githubusercontent.com/8677433/35483505-2eebfa9e-0486-11e8-952b-484602858efe.png" width=300/ ><image src=https://user-images.githubusercontent.com/8677433/35483783-5c9dadae-0489-11e8-9141-a394cdd07bad.png width=300/ >

