### PR TITLE
Define debug authority for SearchSuggestionProvider

### DIFF
--- a/app/src/debug/res/xml/searchable.xml
+++ b/app/src/debug/res/xml/searchable.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<searchable xmlns:android="http://schemas.android.com/apk/res/android"
+    android:hint="@string/search_title"
+    android:includeInGlobalSearch="true"
+    android:label="@string/app_name"
+    android:searchSuggestAuthority="io.github.droidkaigi.confsched2018.debug.presentation.search.SearchSuggestionProvider"
+    android:searchSuggestSelection=" ?"
+    />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -183,7 +183,7 @@
 
         <provider
             android:name=".presentation.search.SearchSuggestionProvider"
-            android:authorities="io.github.droidkaigi.confsched2018.presentation.search.SearchSuggestionProvider"
+            android:authorities="${applicationId}.presentation.search.SearchSuggestionProvider"
             android:exported="false"
             />
     </application>

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSuggestionProvider.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchSuggestionProvider.kt
@@ -1,11 +1,12 @@
 package io.github.droidkaigi.confsched2018.presentation.search
 
 import android.content.SearchRecentSuggestionsProvider
+import io.github.droidkaigi.confsched2018.BuildConfig
 
 class SearchSuggestionProvider : SearchRecentSuggestionsProvider() {
     companion object {
-        val AUTHORITY: String = "io.github.droidkaigi.confsched2018.presentation.search" +
-                ".SearchSuggestionProvider"
+        val AUTHORITY: String =
+                "${BuildConfig.APPLICATION_ID}.presentation.search.SearchSuggestionProvider"
         val MODE: Int = DATABASE_MODE_QUERIES
     }
 


### PR DESCRIPTION
## Issue
- close #505

## Overview (Required)
- Change provider's authority attribute definition as using `${applicationId}`.
- Add `searchable.xml` to `debug`  build type.

I think it is ugly that `searchable.xml` for `debug` build type.
But `searxhable.xml` can not contain placeholder like `${applicationId}`.
I want to fix that if someone have better solution 🙏 