### PR TITLE
Add default text selection menu and 'Web Search' menu to session detail screen

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/binding/TextBinding.kt
@@ -1,5 +1,7 @@
 package io.github.droidkaigi.confsched2018.presentation.common.binding
 
+import android.app.SearchManager
+import android.content.Intent
 import android.databinding.BindingAdapter
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
@@ -10,8 +12,12 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.BackgroundColorSpan
 import android.text.style.StyleSpan
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.TextView
 import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.util.ext.selectedText
 import io.github.droidkaigi.confsched2018.util.ext.toReadableDateTimeString
 import io.github.droidkaigi.confsched2018.util.ext.toReadableTimeString
 import java.util.Date
@@ -92,4 +98,44 @@ fun TextView.setVectorDrawableStart(drawable: Drawable) {
             drawables[2],
             drawables[3]
     )
+}
+
+@BindingAdapter(value = ["android:textIsSelectable", "menuWebSearchEnabled"])
+fun TextView.setTextIsSelectable(selectable: Boolean, menuWebSearchEnabled: Boolean) {
+    setTextIsSelectable(selectable)
+
+    if (selectable) {
+        customSelectionActionModeCallback = object : ActionMode.Callback {
+            override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+                return when {
+                    menuWebSearchEnabled && item?.itemId == R.id.text_view_menu_web_search -> {
+                        Intent(Intent.ACTION_WEB_SEARCH).apply {
+                            putExtra(SearchManager.QUERY, selectedText.toString())
+                            context.startActivity(this)
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            }
+
+            override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+                if (menuWebSearchEnabled) {
+                    menu?.add(Menu.NONE, R.id.text_view_menu_web_search,
+                            Menu.NONE, R.string.web_search)
+                }
+
+                return true
+            }
+
+            override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+                return false
+            }
+
+            override fun onDestroyActionMode(mode: ActionMode?) {
+            }
+        }
+    } else {
+        customSelectionActionModeCallback = null
+    }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailFragment.kt
@@ -21,7 +21,6 @@ import io.github.droidkaigi.confsched2018.util.ext.observe
 import io.github.droidkaigi.confsched2018.util.lang
 import timber.log.Timber
 import javax.inject.Inject
-import io.github.droidkaigi.confsched2018.util.ext.setTextIsSelectable
 
 class SessionDetailFragment : Fragment(), Injectable {
     // TODO create layout
@@ -61,8 +60,6 @@ class SessionDetailFragment : Fragment(), Injectable {
                 }
             }
         }
-
-        binding.sessionText.setTextIsSelectable(true, withWebSearch = true)
 
         binding.detailSessionsPrevSession.setOnClickListener {
             (activity as? OnClickBottomAreaListener)?.onClickPrevSession()

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/detail/SessionDetailFragment.kt
@@ -21,6 +21,7 @@ import io.github.droidkaigi.confsched2018.util.ext.observe
 import io.github.droidkaigi.confsched2018.util.lang
 import timber.log.Timber
 import javax.inject.Inject
+import io.github.droidkaigi.confsched2018.util.ext.setTextIsSelectable
 
 class SessionDetailFragment : Fragment(), Injectable {
     // TODO create layout
@@ -60,6 +61,8 @@ class SessionDetailFragment : Fragment(), Injectable {
                 }
             }
         }
+
+        binding.sessionText.setTextIsSelectable(true, withWebSearch = true)
 
         binding.detailSessionsPrevSession.setOnClickListener {
             (activity as? OnClickBottomAreaListener)?.onClickPrevSession()

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
@@ -15,14 +15,14 @@ fun TextView.setTextIfChanged(newText: String) {
     }
 }
 
-val TextView.selectedText : CharSequence
+val TextView.selectedText: CharSequence
     get() = text.subSequence(selectionStart, selectionEnd)
 
 fun TextView.setTextIsSelectable(selectable: Boolean, withWebSearch: Boolean = false) {
     setTextIsSelectable(selectable)
 
     if (selectable) {
-        customSelectionActionModeCallback = object: ActionMode.Callback {
+        customSelectionActionModeCallback = object : ActionMode.Callback {
             override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
                 return when {
                     withWebSearch && item?.itemId == R.id.text_view_menu_web_search -> {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
@@ -1,10 +1,58 @@
 package io.github.droidkaigi.confsched2018.util.ext
 
+import android.app.SearchManager
+import android.content.Intent
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.TextView
+import io.github.droidkaigi.confsched2018.R
 
 // Prevent requestLayout()
 fun TextView.setTextIfChanged(newText: String) {
     if (newText != text) {
         text = newText
+    }
+}
+
+val TextView.selectedText : CharSequence
+    get() = text.subSequence(selectionStart, selectionEnd)
+
+fun TextView.setTextIsSelectable(selectable: Boolean, withWebSearch: Boolean = false) {
+    setTextIsSelectable(selectable)
+
+    if (selectable) {
+        customSelectionActionModeCallback = object: ActionMode.Callback {
+            override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
+                return when {
+                    withWebSearch && item?.itemId == R.id.text_view_menu_web_search -> {
+                        Intent(Intent.ACTION_WEB_SEARCH).apply {
+                            putExtra(SearchManager.QUERY, selectedText.toString())
+                            context.startActivity(this)
+                        }
+                        true
+                    }
+                    else -> false
+                }
+            }
+
+            override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+                if (withWebSearch) {
+                    menu?.add(Menu.NONE, R.id.text_view_menu_web_search,
+                            Menu.NONE, R.string.web_search)
+                }
+
+                return true
+            }
+
+            override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
+                return false
+            }
+
+            override fun onDestroyActionMode(mode: ActionMode?) {
+            }
+        }
+    } else {
+        customSelectionActionModeCallback = null
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/TextViewExt.kt
@@ -1,12 +1,6 @@
 package io.github.droidkaigi.confsched2018.util.ext
 
-import android.app.SearchManager
-import android.content.Intent
-import android.view.ActionMode
-import android.view.Menu
-import android.view.MenuItem
 import android.widget.TextView
-import io.github.droidkaigi.confsched2018.R
 
 // Prevent requestLayout()
 fun TextView.setTextIfChanged(newText: String) {
@@ -17,42 +11,3 @@ fun TextView.setTextIfChanged(newText: String) {
 
 val TextView.selectedText: CharSequence
     get() = text.subSequence(selectionStart, selectionEnd)
-
-fun TextView.setTextIsSelectable(selectable: Boolean, withWebSearch: Boolean = false) {
-    setTextIsSelectable(selectable)
-
-    if (selectable) {
-        customSelectionActionModeCallback = object : ActionMode.Callback {
-            override fun onActionItemClicked(mode: ActionMode?, item: MenuItem?): Boolean {
-                return when {
-                    withWebSearch && item?.itemId == R.id.text_view_menu_web_search -> {
-                        Intent(Intent.ACTION_WEB_SEARCH).apply {
-                            putExtra(SearchManager.QUERY, selectedText.toString())
-                            context.startActivity(this)
-                        }
-                        true
-                    }
-                    else -> false
-                }
-            }
-
-            override fun onCreateActionMode(mode: ActionMode?, menu: Menu?): Boolean {
-                if (withWebSearch) {
-                    menu?.add(Menu.NONE, R.id.text_view_menu_web_search,
-                            Menu.NONE, R.string.web_search)
-                }
-
-                return true
-            }
-
-            override fun onPrepareActionMode(mode: ActionMode?, menu: Menu?): Boolean {
-                return false
-            }
-
-            override fun onDestroyActionMode(mode: ActionMode?) {
-            }
-        }
-    } else {
-        customSelectionActionModeCallback = null
-    }
-}

--- a/app/src/main/res/layout/fragment_session_detail.xml
+++ b/app/src/main/res/layout/fragment_session_detail.xml
@@ -246,7 +246,7 @@
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="16dp"
-                        android:textIsSelectable="true"
+                        android:textIsSelectable="@{true}"
                         android:layout_marginEnd="16dp"
                         android:layout_marginStart="16dp"
                         android:layout_marginTop="24dp"
@@ -257,6 +257,7 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/session_room"
                         app:layout_constraintVertical_bias="0.0"
+                        app:menuWebSearchEnabled="@{true}"
                         tools:text="A material metaphor is the unifying theory of a rationalized space and a system of motion. The material is grounded in tactile reality, inspired by the study of paper and ink, yet technologically advanced and open to imagination and magic"
                         />
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Common -->
     <string name="time_period">%1$s - %2$s</string>
+    <string name="web_search">ウェブ検索</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_home">ホーム</string>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="text_view_menu_web_search" type="id" />
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <!-- Common -->
     <string name="time_period">%1$s - %2$s</string>
     <string name="room_format" translatable="false">%1$s%2$s</string>
+    <string name="web_search">Web Search</string>
 
     <!-- Preference Keys -->
     <string name="pref_key_enable_local_time" translatable="false">pref_key_enable_local_time</string>


### PR DESCRIPTION
## Issue
- close #517

## Overview (Required)
- Enable to text selection menu on session detail text  in session detail screen.
- Text selection menu contains system default items and 'Web Search'.
- If select 'Web Search' send Intent.ACTION_WEB_SEARCH intent.

## Screenshot
![screenshot_20180129-154951](https://user-images.githubusercontent.com/1004668/35498958-edb3c082-0513-11e8-9da5-79134498cf11.png)

![screenshot_20180129-155003](https://user-images.githubusercontent.com/1004668/35498972-fbaf0430-0513-11e8-86e6-08652333fcea.png)
