### PR TITLE
Update dependencies

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -16,7 +16,7 @@ ext {
             kotshi          : "0.3.0",
             archLifecycle   : "1.1.0",
             archRoom        : "1.0.0",
-            dagger          : "2.13",
+            dagger          : "2.14.1",
             firebase        : "11.6.2", // Adjust version for emulator
             kotpref         : "2.3.0",
             glide           : "4.5.0",

--- a/versions.gradle
+++ b/versions.gradle
@@ -19,7 +19,7 @@ ext {
             dagger          : "2.13",
             firebase        : "11.6.2", // Adjust version for emulator
             kotpref         : "2.3.0",
-            glide           : "4.4.0",
+            glide           : "4.5.0",
             groupie         : "2.0.3",
             stetho          : "1.5.0",
             debot           : "2.0.3",

--- a/versions.gradle
+++ b/versions.gradle
@@ -20,7 +20,7 @@ ext {
             firebase        : "11.6.2", // Adjust version for emulator
             kotpref         : "2.3.0",
             glide           : "4.4.0",
-            groupie         : "2.0.2",
+            groupie         : "2.0.3",
             stetho          : "1.5.0",
             debot           : "2.0.3",
             ossLicenses     : "0.9.1",

--- a/versions.gradle
+++ b/versions.gradle
@@ -74,7 +74,7 @@ ext {
                     compiler: "android.arch.persistence.room:compiler:$versions.archRoom",
             ],
             rxjava2                : [
-                    core   : "io.reactivex.rxjava2:rxjava:2.1.8",
+                    core   : "io.reactivex.rxjava2:rxjava:2.1.9",
                     android: "io.reactivex.rxjava2:rxandroid:2.0.1",
                     kotlin : "io.reactivex.rxjava2:rxkotlin:2.2.0",
             ],

--- a/versions.gradle
+++ b/versions.gradle
@@ -121,7 +121,7 @@ ext {
                     core   : "com.facebook.stetho:stetho:$versions.stetho",
                     okhttp3: "com.facebook.stetho:stetho-okhttp3:$versions.stetho",
             ],
-            crashlytics            : "com.crashlytics.sdk.android:crashlytics:2.7.1@aar",
+            crashlytics            : "com.crashlytics.sdk.android:crashlytics:2.8.0@aar",
             timber                 : "com.jakewharton.timber:timber:4.6.0",
             leakcanary             : "com.squareup.leakcanary:leakcanary-android:1.5.4",
             debot                  : [

--- a/versions.gradle
+++ b/versions.gradle
@@ -137,7 +137,7 @@ ext {
                     multidex: "org.robolectric:shadows-multidex:$versions.robolectric"
             ],
             assertk                : "com.willowtreeapps.assertk:assertk:0.9",
-            threetenbp             : "org.threeten:threetenbp:1.3.3",
+            threetenbp             : "org.threeten:threetenbp:1.3.6",
             supporttest            : [
                     runner  : "com.android.support.test:runner:1.0.1",
                     espresso: "com.android.support.test.espresso:espresso-core:3.0.1",

--- a/versions.gradle
+++ b/versions.gradle
@@ -17,7 +17,7 @@ ext {
             archLifecycle   : "1.1.0",
             archRoom        : "1.0.0",
             dagger          : "2.14.1",
-            firebase        : "11.6.2", // Adjust version for emulator
+            firebase        : "11.8.0", // Adjust version for emulator
             kotpref         : "2.3.0",
             glide           : "4.5.0",
             groupie         : "2.0.3",
@@ -114,7 +114,7 @@ ext {
                     binding: "com.xwray:groupie-databinding:$versions.groupie",
             ],
             downloadableCalligraphy: "com.github.takahirom.downloadable.calligraphy:downloadable-calligraphy:0.1.2",
-            gms                    : "com.google.android.gms:play-services-oss-licenses:11.6.2",
+            gms                    : "com.google.android.gms:play-services-oss-licenses:$versions.firebase",
 
             //==================== Debug ====================
             stetho                 : [


### PR DESCRIPTION
## Issue
- References #384 

## Overview (Required)
Updates libraries that have a later version that is not alpha/beta:
- Groupie
- Glide
- Crashytics
- Dagger2
- Firebase
- RxJava
- ThreeTenABP

I checked on my emulator after each one to make sure the basic functionality is working, but I would like someone else to check also :pray: 
