### PR TITLE
Speaker name is not displayed on SearchSessionsFragment screen.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
@@ -2,6 +2,7 @@ package io.github.droidkaigi.confsched2018.presentation.common.view
 
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Color
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
@@ -31,9 +32,8 @@ class SpeakersSummaryLayout @JvmOverloads constructor(
     private var speakerIdInDetail: String? = null
 
     private fun customAttributesFrom(context: Context, attrs: AttributeSet?): CustomAttributes {
-        val res = context.resources
         val defaultAttributes = CustomAttributes(
-                textColor = 0
+                textColor = Color.BLACK
         )
 
         return attrs?.let {

--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -5,7 +5,6 @@
     >
 
     <data>
-
         <variable
             name="session"
             type="io.github.droidkaigi.confsched2018.model.Session.SpeechSession"
@@ -106,6 +105,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/title"
                 app:speakers="@{session.speakers}"
+                app:textColor="@color/black"
                 />
 
             <io.github.droidkaigi.confsched2018.presentation.common.view.FavoriteButton


### PR DESCRIPTION


## Issue
- close #528 

## Overview (Required)
- Add textColor setting in layout xml.
- Change default value of textColor to opaque color.

## Links
-

## Screenshot
Before | After
:--: | :--:
![search_fail](https://user-images.githubusercontent.com/29206446/35564134-7d4cb30a-05fc-11e8-8297-b016c44f27e5.png) |  ![search_fixed](https://user-images.githubusercontent.com/29206446/35564136-7f5bad90-05fc-11e8-86ad-3cb64fbfc13d.png)
