### PR TITLE
Fix to blink speaker name when favorite button clicked

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/view/SpeakersSummaryLayout.kt
@@ -74,6 +74,7 @@ class SpeakersSummaryLayout @JvmOverloads constructor(
      *     />
      */
     fun setSpeakers(speakers: List<Speaker>) {
+        if (speakerList == speakers) return
         speakerList.clear()
         speakerList.addAll(speakers)
 


### PR DESCRIPTION
## Issue
- Speaker name and icon are blinked when favorite button clicked

## Overview (Required)
- Skip to update speakers when List<Speaker> is not updated

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/7608725/35568632-fd4a6a7e-060c-11e8-8d03-15e496d30425.gif) | ![after](https://user-images.githubusercontent.com/7608725/35568643-008da05c-060d-11e8-9bb7-62b46ac7b578.gif)
