### PR TITLE
Fix #544 BottomNavigationView cannot show with scrolling on grandchild RecyclerView

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/HorizontalSessionsItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/HorizontalSessionsItem.kt
@@ -51,6 +51,7 @@ class HorizontalSessionsItem(
             })
             val linearLayoutManager = layoutManager as LinearLayoutManager
             linearLayoutManager.scrollToPositionWithOffset(scroll.position, scroll.offset)
+            isNestedScrollingEnabled = false
         }
         sessions.forEach {
             items.add(HorizontalSessionItem(


### PR DESCRIPTION
## Issue
- close #544 

## Overview (Required)
- Disable nested scrolling on grandchild RecyclerView

## Layout

This is simplified:

```
CoordinatorLayout
 +- RecyclerView (scroll toward vertical) : child RecyclerView
      +- SessionHeaderItem
      +- HorizontalSessionsItem = grandchild RecyclerView (scroll toward horizontal)
      : 
     and more
 +- BottomNavigationView
```

## Detail

It's caused by confusing to handle nested scroll event from child and grandchild RecyclerView.
We interest only child RecyclerView not grandchild RecyclerView.
Grandchild RecyclerView scrolls via horizontal.
BottomNavigationView shows/hides via vertical scroll.
We don't need to receive nested scroll event from grandchild RecyclerView.

## Screenshot

![after](https://user-images.githubusercontent.com/7608725/35658971-2c821946-0747-11e8-8f98-e5cbe30d03d5.gif)
