### PR TITLE
Fixed a bug that crashes when facebook does not exist

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -164,7 +164,7 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
             uri
         }
 
-        val packageName = CustomTabsHelper.getPackageNameToUse(activity)
+        val chromePackageName = CustomTabsHelper.getPackageNameToUse(activity)
 
         val intent = Intent(Intent.ACTION_VIEW, uri)
         val intentResolveInfo = activity.packageManager.resolveActivity(
@@ -173,7 +173,7 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
         )
 
         intentResolveInfo?.activityInfo?.packageName?.let {
-            if (it != packageName) {
+            if (it != chromePackageName) {
                 // Open specific app
                 activity.startActivity(intent)
                 return
@@ -189,13 +189,13 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
                     intent.putExtra(Intent.EXTRA_REFERRER, appUri)
                 }
 
-        packageName ?: run {
+        chromePackageName ?: run {
             // Cannot use custom tabs.
             activity.startActivity(customTabsIntent.intent.setData(uri))
             return
         }
 
-        customTabsIntent.intent.`package` = packageName
+        customTabsIntent.intent.`package` = chromePackageName
         customTabsIntent.launchUrl(activity, Uri.parse(url))
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -178,7 +178,7 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
         activity.startActivity(customTabsIntent.intent.setData(webUri))
     }
 
-    private fun tryLaunchingSpecificApp(url:String, customTabsPackageName: String?): Boolean {
+    private fun tryLaunchingSpecificApp(url: String, customTabsPackageName: String?): Boolean {
         val appUri = Uri.parse(url).let {
             if (it.host.contains("facebook")) {
                 Uri.parse(FACEBOOK_SCHEME + url)
@@ -200,7 +200,9 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
         return false
     }
 
-    private fun tryUsingCustomTabs(customTabsPackageName: String?, customTabsIntent: CustomTabsIntent, webUri: Uri?): Boolean {
+    private fun tryUsingCustomTabs(customTabsPackageName: String?,
+                                   customTabsIntent: CustomTabsIntent,
+                                   webUri: Uri?): Boolean {
         customTabsPackageName?.let {
             customTabsIntent.intent.`package` = customTabsPackageName
             customTabsIntent.launchUrl(activity, webUri)


### PR DESCRIPTION
## Issue
- No issue.

## Overview (Required)
- Fixed a bug that crash when tap facebook FAB when Facebook App is not installed.
- If Facebook is not installed, crashes because intentResolveInfo is null.
- I think there is a smarter correction method, but I could not think of it😭
- I confirmed it with Android 7.0(SO-02J), 8.0(EssentialPhone)

## 
stackTrace
```
io.github.droidkaigi.confsched2018.debug E/AndroidRuntime: FATAL EXCEPTION: main
                              Process: io.github.droidkaigi.confsched2018.debug, PID: 7908
                              java.lang.NullPointerException: Attempt to read from field 'android.content.pm.ActivityInfo android.content.pm.ResolveInfo.activityInfo' on a null object reference
                                  at io.github.droidkaigi.confsched2018.presentation.NavigationController.navigateToExternalBrowser(NavigationController.kt:171)
                                  at io.github.droidkaigi.confsched2018.presentation.about.AboutThisAppFragment$onAboutThisHeaderIconClickListener$1.invoke(AboutThisAppFragment.kt:25)
                                  at io.github.droidkaigi.confsched2018.presentation.about.AboutThisAppFragment$onAboutThisHeaderIconClickListener$1.invoke(AboutThisAppFragment.kt:19)
                                  at io.github.droidkaigi.confsched2018.presentation.about.item.AboutThisAppHeaderItem$bind$1.onClick(AboutThisAppHeaderItem.kt:26)
                                  at android.view.View.performClick(View.java:5657)
                                  at android.view.View$PerformClick.run(View.java:22314)
                                  at android.os.Handler.handleCallback(Handler.java:751)
                                  at android.os.Handler.dispatchMessage(Handler.java:95)
                                  at android.os.Looper.loop(Looper.java:241)
                                  at android.app.ActivityThread.main(ActivityThread.java:6217)
                                  at java.lang.reflect.Method.invoke(Native Method)
                                  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:865)
                                  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:755)
io.github.droidkaigi.confsched2018.debug I/CrashlyticsCore: Crashlytics report upload complete: 5A731D59027A-0001-1EE4-7A35EC3832C2
```

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
