### PR TITLE
 Use top-level function instead of object class.

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/App.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/App.kt
@@ -15,7 +15,7 @@ import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasActivityInjector
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.di.initDaggerComponent
-import io.github.droidkaigi.confsched2018.presentation.common.notification.NotificationHelper
+import io.github.droidkaigi.confsched2018.presentation.common.notification.initNotificationChannel
 import timber.log.Timber
 import uk.co.chrisjenx.calligraphy.CalligraphyConfig
 import javax.inject.Inject
@@ -87,7 +87,7 @@ open class App : MultiDexApplication(), HasActivityInjector {
     }
 
     private fun setupNotification() {
-        NotificationHelper.initNotificationChannel(this)
+        initNotificationChannel()
     }
 
     override fun activityInjector(): DispatchingAndroidInjector<Activity> =

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/LocaleChangedBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/LocaleChangedBroadcastReceiver.kt
@@ -6,10 +6,10 @@ import android.content.Intent
 import timber.log.Timber
 
 class LocaleChangedBroadcastReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context?, intent: Intent?) {
+    override fun onReceive(context: Context, intent: Intent?) {
         Timber.d("LocaleChangedBroadcastReceiver.onReceive")
         if (Intent.ACTION_LOCALE_CHANGED == intent?.action) {
-            NotificationHelper.initNotificationChannel(context!!)
+            context.initNotificationChannel()
         }
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationBroadcastReceiver.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationBroadcastReceiver.kt
@@ -7,7 +7,7 @@ import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 import timber.log.Timber
 
 class NotificationBroadcastReceiver : BroadcastReceiver() {
-    override fun onReceive(context: Context?, intent: Intent?) {
+    override fun onReceive(context: Context, intent: Intent?) {
         Timber.d("NotificationBroadcastReceiver.onReceive")
 
         if (!Prefs.enableNotification) {
@@ -16,10 +16,7 @@ class NotificationBroadcastReceiver : BroadcastReceiver() {
         }
 
         intent ?: return
-        context ?: return
-
-        val notificationContent = NotificationContent.parse(intent)
-        NotificationHelper.showNotification(context, notificationContent)
+        context.showNotification(NotificationContent.parse(intent))
     }
 
     companion object {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationContent.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationContent.kt
@@ -10,7 +10,7 @@ import io.github.droidkaigi.confsched2018.presentation.detail.SessionDetailActiv
 sealed class NotificationContent(
         open val title: String,
         open val text: String,
-        val channelType: NotificationHelper.ChannelType
+        val channelType: NotificationChannelType
 ) {
     enum class NotificationType {
         FAVORITE_SESSION_START_NOTIFICATION
@@ -23,7 +23,7 @@ sealed class NotificationContent(
     ) : NotificationContent(
             title,
             text,
-            NotificationHelper.ChannelType.FAVORITE_SESSION_START
+            NotificationChannelType.FAVORITE_SESSION_START
     ) {
         override fun createPendingContentIntent(context: Context): PendingIntent {
             return TaskStackBuilder

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationHelper.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationHelper.kt
@@ -11,52 +11,45 @@ import android.support.v4.app.NotificationManagerCompat
 import android.support.v4.content.ContextCompat
 import io.github.droidkaigi.confsched2018.R
 
-/**
- * Helper class for Notification.
- */
-object NotificationHelper {
-    enum class ChannelType(
-            val id: String,
-            @StringRes val nameRes: Int,
-            val importance: Int
-    ) {
-        FAVORITE_SESSION_START(
-                "favorite_session_start_channel",
-                R.string.notification_channel_name_start_favorite_session,
-                NotificationManager.IMPORTANCE_HIGH
-        );
-    }
+enum class NotificationChannelType(
+        val id: String,
+        @StringRes val nameRes: Int,
+        val importance: Int
+) {
+    FAVORITE_SESSION_START(
+            "favorite_session_start_channel",
+            R.string.notification_channel_name_start_favorite_session,
+            NotificationManager.IMPORTANCE_HIGH
+    );
+}
 
-    fun initNotificationChannel(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            ChannelType.values().forEach {
-                createNotificationChannel(context, it)
-            }
-        }
+fun Context.initNotificationChannel() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        NotificationChannelType.values().forEach(::createNotificationChannel)
     }
+}
 
-    @RequiresApi(Build.VERSION_CODES.O)
-    private fun createNotificationChannel(context: Context, channelType: ChannelType) {
-        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val channelName = context.getString(channelType.nameRes)
-        val channel = NotificationChannel(channelType.id, channelName, channelType.importance)
-        manager.createNotificationChannel(channel)
-    }
+@RequiresApi(Build.VERSION_CODES.O)
+private fun Context.createNotificationChannel(channelType: NotificationChannelType) {
+    (getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+            .createNotificationChannel(NotificationChannel(
+                    channelType.id,
+                    getString(channelType.nameRes),
+                    channelType.importance
+            ))
+}
 
-    fun showNotification(
-            context: Context,
-            content: NotificationContent
-    ) {
-        val notification =
-                NotificationCompat.Builder(context, content.channelType.id)
-                        .setContentTitle(content.title)
-                        .setContentText(content.text)
-                        .setFullScreenIntent(content.createPendingContentIntent(context), true)
-                        .setAutoCancel(true)
-                        .setColor(ContextCompat.getColor(context, R.color.primary))
-                        .setSmallIcon(R.drawable.ic_notification).build()
-
-        val manager = NotificationManagerCompat.from(context)
-        manager.notify(content.text.hashCode(), notification)
-    }
+fun Context.showNotification(
+        content: NotificationContent
+) {
+    NotificationManagerCompat.from(this).notify(
+            content.text.hashCode(),
+            NotificationCompat.Builder(this, content.channelType.id)
+                    .setContentTitle(content.title)
+                    .setContentText(content.text)
+                    .setFullScreenIntent(content.createPendingContentIntent(this), true)
+                    .setAutoCancel(true)
+                    .setColor(ContextCompat.getColor(this, R.color.primary))
+                    .setSmallIcon(R.drawable.ic_notification).build()
+    )
 }


### PR DESCRIPTION
## Issue
- No issue.

## Overview (Required)
- Use top-level function instead of object class.

Like #556, there is room for discussion for this.
I prefer top-level function to (companion) object object class.
This opinion is based on [`Kotlin in Action`](https://www.amazon.co.jp/Kotlin%E3%82%A4%E3%83%B3%E3%83%BB%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3-Dmitry-Jemerov/dp/4839961743)(chapter 4.4.2).

The detailed explanation is in the following blog(in Japanese).
http://hydrakecat.hatenablog.jp/entry/2017/12/02/companion_object_vs._top-level

### Changes

These are decompiled java code.

#### Before

```java
public final class NotificationHelper {
   public static final NotificationHelper INSTANCE;

   public final void initNotificationChannel(@NotNull Context context) {
      Intrinsics.checkParameterIsNotNull(context, "context");
      if(VERSION.SDK_INT >= 26) {
         Object[] $receiver$iv = (Object[])NotificationHelper.ChannelType.values();
         int var3 = $receiver$iv.length;

         for(int var4 = 0; var4 < var3; ++var4) {
            Object element$iv = $receiver$iv[var4];
            NotificationHelper.ChannelType it = (NotificationHelper.ChannelType)element$iv;
            INSTANCE.createNotificationChannel(context, it);
         }
      }

   }

   @RequiresApi(26)
   private final void createNotificationChannel(Context context, NotificationHelper.ChannelType channelType) {
      Object var10000 = context.getSystemService("notification");
      if(var10000 == null) {
         throw new TypeCastException("null cannot be cast to non-null type android.app.NotificationManager");
      } else {
         NotificationManager manager = (NotificationManager)var10000;
         String channelName = context.getString(channelType.getNameRes());
         NotificationChannel channel = new NotificationChannel(channelType.getId(), (CharSequence)channelName, channelType.getImportance());
         manager.createNotificationChannel(channel);
      }
   }

   public final void showNotification(@NotNull Context context, @NotNull NotificationContent content) {
      Intrinsics.checkParameterIsNotNull(context, "context");
      Intrinsics.checkParameterIsNotNull(content, "content");
      Notification notification = (new Builder(context, content.getChannelType().getId())).setContentTitle((CharSequence)content.getTitle()).setContentText((CharSequence)content.getText()).setFullScreenIntent(content.createPendingContentIntent(context), true).setAutoCancel(true).setColor(ContextCompat.getColor(context, 2131099750)).setSmallIcon(2131230882).build();
      NotificationManagerCompat manager = NotificationManagerCompat.from(context);
      manager.notify(content.getText().hashCode(), notification);
   }

   static {
      NotificationHelper var0 = new NotificationHelper();
      INSTANCE = var0;
   }

   public static enum ChannelType {
      FAVORITE_SESSION_START;

      @NotNull
      private final String id;
      private final int nameRes;
      private final int importance;

      @NotNull
      public final String getId() {
         return this.id;
      }

      public final int getNameRes() {
         return this.nameRes;
      }

      public final int getImportance() {
         return this.importance;
      }

      protected ChannelType(@NotNull String id, @StringRes int nameRes, int importance) {
         Intrinsics.checkParameterIsNotNull(id, "id");
         super($enum_name_or_ordinal$0, $enum_name_or_ordinal$1);
         this.id = id;
         this.nameRes = nameRes;
         this.importance = importance;
      }
   }
}
```

- `NotificationHelper` is singleton.

#### After

```java
public final class NotificationHelperKt {
   public static final void initNotificationChannel(@NotNull Context $receiver) {
      Intrinsics.checkParameterIsNotNull($receiver, "$receiver");
      if(VERSION.SDK_INT >= 26) {
         Object[] $receiver$iv = (Object[])NotificationChannelType.values();
         int var2 = $receiver$iv.length;

         for(int var3 = 0; var3 < var2; ++var3) {
            Object element$iv = $receiver$iv[var3];
            NotificationChannelType p1 = (NotificationChannelType)element$iv;
            createNotificationChannel($receiver, p1);
         }
      }

   }

   @RequiresApi(26)
   private static final void createNotificationChannel(@NotNull Context $receiver, NotificationChannelType channelType) {
      Object var10000 = $receiver.getSystemService("notification");
      if(var10000 == null) {
         throw new TypeCastException("null cannot be cast to non-null type android.app.NotificationManager");
      } else {
         ((NotificationManager)var10000).createNotificationChannel(new NotificationChannel(channelType.getId(), (CharSequence)$receiver.getString(channelType.getNameRes()), channelType.getImportance()));
      }
   }

   public static final void showNotification(@NotNull Context $receiver, @NotNull NotificationContent content) {
      Intrinsics.checkParameterIsNotNull($receiver, "$receiver");
      Intrinsics.checkParameterIsNotNull(content, "content");
      NotificationManagerCompat.from($receiver).notify(content.getText().hashCode(), (new Builder($receiver, content.getChannelType().getId())).setContentTitle((CharSequence)content.getTitle()).setContentText((CharSequence)content.getText()).setFullScreenIntent(content.createPendingContentIntent($receiver), true).setAutoCancel(true).setColor(ContextCompat.getColor($receiver, 2131099750)).setSmallIcon(2131230882).build());
   }
}

public enum NotificationChannelType {
   FAVORITE_SESSION_START;

   @NotNull
   private final String id;
   private final int nameRes;
   private final int importance;

   @NotNull
   public final String getId() {
      return this.id;
   }

   public final int getNameRes() {
      return this.nameRes;
   }

   public final int getImportance() {
      return this.importance;
   }

   protected NotificationChannelType(@NotNull String id, @StringRes int nameRes, int importance) {
      Intrinsics.checkParameterIsNotNull(id, "id");
      super($enum_name_or_ordinal$0, $enum_name_or_ordinal$1);
      this.id = id;
      this.nameRes = nameRes;
      this.importance = importance;
   }
}
```

#### Other change.

- `context` parameter of `BroadcastReceiver::onReceive` is changed to Non-Null.

This is because it is assumed that it will not become Non-Null. 
Even if it falls to Null, it falls before the calling `context` (falls by `Intrinsics.checkParameterIsNotNull(context, "context");`), so you can quickly find a bug.
I guess that this also is certainly described in `Kotlin in Action`.

## Links
- http://hydrakecat.hatenablog.jp/entry/2017/12/02/companion_object_vs._top-level

## Screenshot
Nothing has changed.
And this changes is hard to test 🙏 .
