### PR TITLE
Add padding to the map and transition info in the Access Screen

### DIFF
--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -62,6 +62,8 @@
                 <android.support.constraint.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingBottom="8dp"
+                    android:paddingTop="16dp"
                     >
                     <ImageView
                         android:layout_width="wrap_content"
@@ -95,6 +97,8 @@
                 <android.support.constraint.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingBottom="16dp"
+                    android:paddingTop="8dp"
                     >
                     <ImageView
                         android:layout_width="wrap_content"


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- Add padding to the map and transition info in the Access Screen

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/8059722/35764992-b46c046c-08fe-11e8-9f51-0044a218c9a5.png" width="300" /> | <img src="https://user-images.githubusercontent.com/8059722/35764999-cc1fac1c-08fe-11e8-9bbf-6a48605bc89a.png" width="300" />

