### PR TITLE
Avoid calling tab select listener

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -96,7 +96,8 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         sessionsViewPagerAdapter = SessionsViewPagerAdapter(childFragmentManager, activity!!)
         sessionsViewPagerAdapter.registerDataSetObserver(object : DataSetObserver() {
             override fun onChanged() {
-                binding.tabLayout.getTabAt(0)?.select()
+                binding.tabLayout.setScrollPosition(0, 0f, true)
+                binding.sessionsViewPager.currentItem = 0
             }
         })
         binding.sessionsViewPager.adapter = sessionsViewPagerAdapter


### PR DESCRIPTION
## Issue
- close https://github.com/DroidKaigi/conference-app-2018/issues/583#issuecomment-362875416

## Overview (Required)
- OnTabSelectListener touched fragment's binding even though it has not been initialized.

## Links
-