### PR TITLE
Faster Circle CI build by caching Bundle install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,15 @@ jobs:
           key: sdks-licenses-build-tools-extras-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+      - restore_cache:
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Bundle install
-          command: bundle instal
+          command: bundle install --path vendor/bundle
+      - save_cache:
+          paths:
+            - vendor/bundle
+          key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies


### PR DESCRIPTION
## Issue
- close #580

## Overview (Required)
- add steps of bundle save cache and bundle restore cache

## Links
- [Using cache build](https://circleci.com/gh/DroidKaigi/conference-app-2018/1202)
