### PR TITLE
Stop caching fragments on SearchFragment

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/NoticeDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/NoticeDataMapperExt.kt
@@ -12,10 +12,10 @@ fun List<io.github.droidkaigi.confsched2018.data.api.response.Post>.toFeeds():
             published = it.published!!,
             type = it.type!!.let {
                 when (it) {
-                    "tutorial" -> Post.Type.Tutorial
-                    "notification" -> Post.Type.Notification
-                    "alert" -> Post.Type.Alert
-                    "enquete" -> Post.Type.Feedback
+                    "tutorial" -> Post.Type.TUTORIAL
+                    "notification" -> Post.Type.NOTIFICATION
+                    "alert" -> Post.Type.ALERT
+                    "enquete" -> Post.Type.FEEDBACK
                     else -> throw IllegalStateException("unsupported Post type.")
                 }
             }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/feed/item/FeedItem.kt
@@ -32,10 +32,10 @@ data class FeedItem(
         viewBinding.post = post
 
         viewBinding.feedIcon.setImageResource(when (post.type) {
-            Post.Type.Tutorial -> R.drawable.ic_feed_tutorial_pink_20dp
-            Post.Type.Notification -> R.drawable.ic_feed_notification_blue_20dp
-            Post.Type.Alert -> R.drawable.ic_feed_alert_amber_20dp
-            Post.Type.Feedback -> R.drawable.ic_feed_feedback_cyan_20dp
+            Post.Type.TUTORIAL -> R.drawable.ic_feed_tutorial_pink_20dp
+            Post.Type.NOTIFICATION -> R.drawable.ic_feed_notification_blue_20dp
+            Post.Type.ALERT -> R.drawable.ic_feed_alert_amber_20dp
+            Post.Type.FEEDBACK -> R.drawable.ic_feed_feedback_cyan_20dp
         })
 
         viewBinding.content.onClickUrl = onClickUri

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -236,10 +236,21 @@ class SearchBeforeViewPagerAdapter(
         }
     }
 
-    enum class Tab(@StringRes val title: Int, val fragment: Fragment) {
-        Session(R.string.search_before_tab_session, SearchSessionsFragment.newInstance()),
-        Topic(R.string.search_before_tab_topic, SearchTopicsFragment.newInstance()),
-        Speakers(R.string.search_before_tab_speaker, SearchSpeakersFragment.newInstance());
+    enum class Tab(@StringRes val title: Int) {
+        Session(R.string.search_before_tab_session) {
+            override val fragment: Fragment
+                get() = SearchSessionsFragment.newInstance()
+        },
+        Topic(R.string.search_before_tab_topic) {
+            override val fragment: Fragment
+                get() = SearchTopicsFragment.newInstance()
+        },
+        Speakers(R.string.search_before_tab_speaker) {
+            override val fragment: Fragment
+                get() = SearchSpeakersFragment.newInstance()
+        };
+
+        abstract val fragment: Fragment
     }
 
     override fun getPageTitle(position: Int): CharSequence =

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/SearchFragment.kt
@@ -237,15 +237,15 @@ class SearchBeforeViewPagerAdapter(
     }
 
     enum class Tab(@StringRes val title: Int) {
-        Session(R.string.search_before_tab_session) {
+        SESSION(R.string.search_before_tab_session) {
             override val fragment: Fragment
                 get() = SearchSessionsFragment.newInstance()
         },
-        Topic(R.string.search_before_tab_topic) {
+        TOPIC(R.string.search_before_tab_topic) {
             override val fragment: Fragment
                 get() = SearchTopicsFragment.newInstance()
         },
-        Speakers(R.string.search_before_tab_speaker) {
+        SPEAKERS(R.string.search_before_tab_speaker) {
             override val fragment: Fragment
                 get() = SearchSpeakersFragment.newInstance()
         };

--- a/model/src/main/java/io/github/droidkaigi/confsched2018/model/Post.kt
+++ b/model/src/main/java/io/github/droidkaigi/confsched2018/model/Post.kt
@@ -10,9 +10,9 @@ data class Post(
         val type: Type
 ) {
     enum class Type {
-        Tutorial,
-        Notification,
-        Alert,
-        Feedback,
+        TUTORIAL,
+        NOTIFICATION,
+        ALERT,
+        FEEDBACK,
     }
 }


### PR DESCRIPTION
## Issue
- close #590

## Overview (Required)
- Stop caching fragments on SearchFragment. like this https://github.com/DroidKaigi/conference-app-2018/pull/493/files#diff-8fa8830b5e88e5e809ec4e5ea4be2e6cR195
- Actually, I don't know whether this problem has definitely been fixed.
But this has not occured now... 🤔 