### PR TITLE
Add PageMargin to ViewPager in SessionsFragment

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -101,6 +101,8 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
             }
         })
         binding.sessionsViewPager.adapter = sessionsViewPagerAdapter
+        binding.sessionsViewPager.pageMargin =
+                resources.getDimensionPixelSize(R.dimen.session_page_margin)
 
         sessionsViewModel = ViewModelProviders
                 .of(this, viewModelFactory)

--- a/app/src/main/res/layout/fragment_all_sessions.xml
+++ b/app/src/main/res/layout/fragment_all_sessions.xml
@@ -10,6 +10,7 @@
         android:id="@+id/sessions_constraint_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipChildren="false"
         >
 
         <android.support.v7.widget.RecyclerView
@@ -17,6 +18,7 @@
             style="@style/BaseRecyclerView"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:clipChildren="false"
             android:clipToPadding="false"
             android:orientation="vertical"
             android:paddingBottom="@dimen/session_recycler_bottom_padding"

--- a/app/src/main/res/layout/fragment_room_sessions.xml
+++ b/app/src/main/res/layout/fragment_room_sessions.xml
@@ -12,6 +12,7 @@
         android:id="@+id/sessions_constraint_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:clipChildren="false"
         >
 
         <android.support.v7.widget.RecyclerView
@@ -19,6 +20,7 @@
             style="@style/BaseRecyclerView"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:clipChildren="false"
             android:clipToPadding="false"
             android:orientation="vertical"
             android:paddingBottom="@dimen/session_recycler_bottom_padding"

--- a/app/src/main/res/layout/fragment_sessions.xml
+++ b/app/src/main/res/layout/fragment_sessions.xml
@@ -31,6 +31,7 @@
             android:id="@+id/sessions_view_pager"
             android:layout_width="0dp"
             android:layout_height="0dp"
+            android:clipChildren="false"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,6 +4,7 @@
     <dimen name="session_title_line_spacing">4sp</dimen>
     <dimen name="session_recycler_top_padding">12dp</dimen>
     <dimen name="session_recycler_bottom_padding">4dp</dimen>
+    <dimen name="session_page_margin">16dp</dimen>
 
     <!-- Feed -->
     <dimen name="feed_expand_button_size">20dp</dimen>


### PR DESCRIPTION
## Issue
- This PR has no issue 🙇 

## Overview (Required)
- *This is just suggestion.*  🙌 
- Add page margin `16dp` to ViewPager in SessionFragment.
- I think each cards should be splitted, but there are sticking to cards in next page. 

### Details
- This margin can be seen when only scrolling.
- set `Viewpager.pageMargin` is not enough, and to achieve this correctly, we have to add `android:clipChildren="false"` to parents of CardView. (To show left and right shadow of CardView.)

## Links
- No links.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/19567429/35776827-d76d10d0-09e6-11e8-8c47-c01aae3c4faa.png" width="300" /> | <img src="https://user-images.githubusercontent.com/19567429/35776836-e37e6964-09e6-11e8-9335-accffbd5634b.png" width="300" />


