### PR TITLE
Fix: horizontal sessions scroll to wrong position on favorited

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/HorizontalSessionsItem.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/search/item/HorizontalSessionsItem.kt
@@ -14,6 +14,7 @@ import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.ItemSearchHorizontalSessionsBinding
 import io.github.droidkaigi.confsched2018.model.Level
 import io.github.droidkaigi.confsched2018.model.Session
+import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
 
 class HorizontalSessionsItem(
         val level: Level,
@@ -35,6 +36,10 @@ class HorizontalSessionsItem(
             onItemLongClickListener: OnItemLongClickListener?
     ) {
         this.onItemClickListener = onItemClickListener!!
+        // Save scroll position on scrolled
+        holder.binding.searchSessionsRecycler.addOnScrollListener(
+                onScrolled = { _, _, _ -> saveScrollPosition(holder) }
+        )
         super.bind(holder, position, payloads, onItemClickListener, onItemLongClickListener)
     }
 
@@ -64,8 +69,7 @@ class HorizontalSessionsItem(
         section.update(items)
     }
 
-    override fun unbind(holder: ViewHolder<ItemSearchHorizontalSessionsBinding>) {
-        // Save scroll position to HashMap
+    private fun saveScrollPosition(holder: ViewHolder<ItemSearchHorizontalSessionsBinding>) {
         val searchSessionsRecycler = holder.binding.searchSessionsRecycler
         val linearLayoutManager = searchSessionsRecycler.layoutManager as LinearLayoutManager
         val position = linearLayoutManager.findFirstVisibleItemPosition()
@@ -76,7 +80,6 @@ class HorizontalSessionsItem(
                 linearLayoutManager.getPosition(holder.root),
                 LevelSessionsSection.PositionAndOffset(position, x.toInt())
         )
-        super.unbind(holder)
     }
 
     override fun getLayout(): Int = R.layout.item_search_horizontal_sessions

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
@@ -7,8 +7,10 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 
 inline fun RecyclerView.addOnScrollListener(
-        crossinline onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit = { _, _ -> },
-        crossinline onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit = { _, _, _ -> }
+        crossinline onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit
+        = { _, _ -> },
+        crossinline onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit
+        = { _, _, _ -> }
 ) {
     addOnScrollListener(object : RecyclerView.OnScrollListener() {
         override fun onScrollStateChanged(recyclerView: RecyclerView?, newState: Int) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
@@ -7,10 +7,10 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 
 inline fun RecyclerView.addOnScrollListener(
-        crossinline onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit
-        = { _, _ -> },
-        crossinline onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit
-        = { _, _, _ -> }
+        crossinline onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit =
+        { _, _ -> },
+        crossinline onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit =
+        { _, _, _ -> }
 ) {
     addOnScrollListener(object : RecyclerView.OnScrollListener() {
         override fun onScrollStateChanged(recyclerView: RecyclerView?, newState: Int) {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/RecyclerViewExt.kt
@@ -6,9 +6,9 @@ import android.support.v7.widget.DividerItemDecoration
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 
-fun RecyclerView.addOnScrollListener(
-        onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit,
-        onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit
+inline fun RecyclerView.addOnScrollListener(
+        crossinline onScrollStateChanged: (recyclerView: RecyclerView?, newState: Int) -> Unit = { _, _ -> },
+        crossinline onScrolled: (recyclerView: RecyclerView?, dx: Int, dy: Int) -> Unit = { _, _, _ -> }
 ) {
     addOnScrollListener(object : RecyclerView.OnScrollListener() {
         override fun onScrollStateChanged(recyclerView: RecyclerView?, newState: Int) {


### PR DESCRIPTION
## Issue
- No issue

## Overview (Required)
- Fix `HorizontalSessionsItem`'s scroll position is not saved on favorited
- Make `RecyclerView.addOnScrollListener` to inline function

## Links
- 

## Screenshot
Before | After
:--: | :--:
![kekka](https://user-images.githubusercontent.com/5885032/35776797-55c881ae-09e6-11e8-9bd6-32f40760f70b.gif) | ![kekka](https://user-images.githubusercontent.com/5885032/35776796-5088cd98-09e6-11e8-9c0c-2f0024ca5b74.gif)

## 個人的なメモ
- [DiffUtil.Callback#getChangePayload](https://developer.android.com/reference/android/support/v7/util/DiffUtil.Callback.html#getChangePayload(int, int))がnullならViewHolderの再生成される。
- その際、同じpositionのViewHolderがもう一つ生成され、newViewHolder.bind -> oldViewHolder.unbindの順で呼ばれる。
- 故に、お気に入りされてnotifyChangeされるとスクロール位置が狂っていた。
- groupieにはpayloadのサポートがない。