### PR TITLE
Fix card layout of search screen.

### DIFF
--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -13,7 +13,7 @@
 
     <android.support.v7.widget.CardView
         android:layout_width="match_parent"
-        android:layout_height="166dp"
+        android:layout_height="210dp"
         android:layout_marginBottom="4dp"
         android:layout_marginEnd="8dp"
         android:layout_marginStart="8dp"
@@ -83,23 +83,26 @@
                 android:id="@+id/title"
                 style="@style/TextStyle.App.Title"
                 android:layout_width="0dp"
-                android:layout_height="62dp"
+                android:layout_height="0dp"
                 android:layout_marginEnd="16dp"
                 android:layout_marginStart="12dp"
                 android:layout_marginTop="10dp"
                 android:ellipsize="end"
                 android:lineSpacingExtra="@dimen/session_title_line_spacing"
-                android:maxLines="2"
+                android:maxLines="@{4 - session.speakers.size}"
                 android:text="@{session.title}"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/period"
+                app:layout_constraintBottom_toTopOf="@id/speakers"
                 tools:text="テストセッション"
                 />
 
             <io.github.droidkaigi.confsched2018.presentation.common.view.SpeakersSummaryLayout
+                android:id="@+id/speakers"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                tools:layout_height="70dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/favorite"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## Issue
- close #596 

## Overview (Required)
I've increased the height of session card, and changed maxLines of session title TextView depend on number of speakers to avoid large blank space.

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/10704349/35777996-1389d378-09fb-11e8-91ed-7d79de3ba4ae.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/35778004-17a881de-09fb-11e8-8f90-d96864e4b0e6.png" width="300" />

## Appendix
Screenshots for 1 or 2 speaker(s)
<img src="https://user-images.githubusercontent.com/10704349/35778005-17d1d606-09fb-11e8-8a5a-7d29af210875.png" width="300" />
<img src="https://user-images.githubusercontent.com/10704349/35778006-17fac340-09fb-11e8-9191-825e9f07c290.png" width="300" />