### PR TITLE
Save tab and scroll position which is shown before.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,7 @@ dependencies {
 
     implementation depends.kotpref.kotpref
     implementation depends.kotpref.initializer
+    implementation depends.kotpref.enumSupport
 
     //==================== UI ====================
     implementation depends.glide.core

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -1,39 +1,38 @@
 package io.github.droidkaigi.confsched2018.presentation.common.pref
 
 import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.enumpref.enumValuePref
 import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.presentation.sessions.SessionTabMode
 import io.github.droidkaigi.confsched2018.util.ext.bool
 import io.github.droidkaigi.confsched2018.util.ext.integer
 
 object Prefs : KotprefModel() {
     public override val kotprefName: String = "droidkaigi_prefs"
     var enableLocalTime: Boolean by booleanPref(
-            context.bool(R.bool.pref_default_value_enable_local_time),
-            R.string.pref_key_enable_local_time
+            default = context.bool(R.bool.pref_default_value_enable_local_time),
+            key = R.string.pref_key_enable_local_time
     )
     var enableNotification: Boolean by booleanPref(
-            context.bool(R.bool.pref_default_value_enable_notification),
-            R.string.pref_key_enable_notification
+            default = context.bool(R.bool.pref_default_value_enable_notification),
+            key = R.string.pref_key_enable_notification
     )
     var enableHideBottomNavigationBar: Boolean by booleanPref(
-            context.bool(R.bool.pref_default_value_enable_hide_bottom_navigation),
-            R.string.pref_key_enable_hide_bottom_navigation
+            default = context.bool(R.bool.pref_default_value_enable_hide_bottom_navigation),
+            key = R.string.pref_key_enable_hide_bottom_navigation
     )
     var enableReopenPreviousRoomSessions: Boolean by booleanPref(
-            context.bool(R.bool.pref_default_value_enable_reopen_previous_room_sessions),
-            R.string.pref_key_enable_reopen_previous_room_sessions
+            default = context.bool(R.bool.pref_default_value_enable_reopen_previous_room_sessions),
+            key = R.string.pref_key_enable_reopen_previous_room_sessions
     )
-    var previousSessionTab: String by stringPref(
-            context.getString(R.string.pref_default_value_previous_session_tab)
-    )
+    var previousSessionTab by enumValuePref(SessionTabMode.ROOM)
     var previousSessionTabId: Int by intPref(
-            context.integer(R.integer.pref_default_value_previous_session_tab_id)
+            default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
 }
 
 fun initPreviousSessionPrefs() {
-    Prefs.previousSessionTab = Prefs.context.getString(
-            R.string.pref_default_value_previous_session_tab)
+    Prefs.previousSessionTab = SessionTabMode.ROOM
     Prefs.previousSessionTabId = Prefs.context.integer(
-            R.integer.pref_default_value_previous_session_tab_id)
+            integerRes = R.integer.pref_default_value_previous_session_tab_id)
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -29,10 +29,10 @@ object Prefs : KotprefModel() {
     var previousSessionTabId: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
-}
 
-fun initPreviousSessionPrefs() {
-    Prefs.previousSessionTab = SessionTabMode.ROOM
-    Prefs.previousSessionTabId = Prefs.context.integer(
-            integerRes = R.integer.pref_default_value_previous_session_tab_id)
+    fun initPreviousSessionPrefs() {
+        Prefs.previousSessionTab = SessionTabMode.ROOM
+        Prefs.previousSessionTabId = Prefs.context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_tab_id)
+    }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -25,13 +25,13 @@ object Prefs : KotprefModel() {
             default = context.bool(R.bool.pref_default_value_enable_reopen_previous_room_sessions),
             key = R.string.pref_key_enable_reopen_previous_room_sessions
     )
-    var previousSessionTab by enumValuePref(SessionTabMode.ROOM)
+    var previousSessionTabMode by enumValuePref(SessionTabMode.ROOM)
     var previousSessionTabId: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
 
     fun initPreviousSessionPrefs() {
-        Prefs.previousSessionTab = SessionTabMode.ROOM
+        Prefs.previousSessionTabMode = SessionTabMode.ROOM
         Prefs.previousSessionTabId = Prefs.context.integer(
                 integerRes = R.integer.pref_default_value_previous_session_tab_id)
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -3,6 +3,7 @@ package io.github.droidkaigi.confsched2018.presentation.common.pref
 import com.chibatching.kotpref.KotprefModel
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.util.ext.bool
+import io.github.droidkaigi.confsched2018.util.ext.integer
 
 object Prefs : KotprefModel() {
     public override val kotprefName: String = "droidkaigi_prefs"
@@ -18,4 +19,23 @@ object Prefs : KotprefModel() {
             context.bool(R.bool.pref_default_value_enable_hide_bottom_navigation),
             R.string.pref_key_enable_hide_bottom_navigation
     )
+    var enableReopenPreviousRoomSessions: Boolean by booleanPref(
+            context.bool(R.bool.pref_default_value_enable_reopen_previous_room_sessions),
+            R.string.pref_key_enable_reopen_previous_room_sessions
+    )
+    var previousSessionTab: String by stringPref(
+            context.getString(R.string.pref_default_value_previous_session_tab),
+            R.string.pref_key_previous_session_tab
+    )
+    var previousSessionTabId: Int by intPref(
+            context.integer(R.integer.pref_default_value_previous_session_tab_id),
+            R.string.pref_key_previous_session_tab_id
+    )
+}
+
+fun initPreviousSessionPrefs() {
+    Prefs.previousSessionTab = Prefs.context.getString(
+            R.string.pref_default_value_previous_session_tab)
+    Prefs.previousSessionTabId = Prefs.context.integer(
+            R.integer.pref_default_value_previous_session_tab_id)
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -24,12 +24,10 @@ object Prefs : KotprefModel() {
             R.string.pref_key_enable_reopen_previous_room_sessions
     )
     var previousSessionTab: String by stringPref(
-            context.getString(R.string.pref_default_value_previous_session_tab),
-            R.string.pref_key_previous_session_tab
+            context.getString(R.string.pref_default_value_previous_session_tab)
     )
     var previousSessionTabId: Int by intPref(
-            context.integer(R.integer.pref_default_value_previous_session_tab_id),
-            R.string.pref_key_previous_session_tab_id
+            context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
 }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -110,7 +110,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
                 .get(SessionsViewModel::class.java)
 
         if (Prefs.enableReopenPreviousRoomSessions and (savedInstanceState == null)) {
-            sessionsViewModel.changeTabMode(Prefs.previousSessionTab)
+            sessionsViewModel.changeTabMode(Prefs.previousSessionTabMode)
         }
 
         val progressTimeLatch = ProgressTimeLatch {
@@ -166,7 +166,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
     private fun saveCurrentSession() {
         val currentItem = binding.sessionsViewPager.currentItem
         Prefs.previousSessionTabId = currentItem
-        Prefs.previousSessionTab = sessionsViewModel.tabMode
+        Prefs.previousSessionTabMode = sessionsViewModel.tabMode
     }
 
     override fun onReselected() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -198,6 +198,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         if (previousItem < 0) return
 
         binding.sessionsViewPager.currentItem = previousItem
+        initPreviousSessionPrefs()
     }
 
     override val tagForFinding = MainActivity.BottomNavigationItem.SESSION.name

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -27,7 +27,6 @@ import io.github.droidkaigi.confsched2018.presentation.MainActivity.BottomNaviga
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.common.fragment.Findable
 import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
-import io.github.droidkaigi.confsched2018.presentation.common.pref.initPreviousSessionPrefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedDispatcher
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.ext.observe
@@ -160,7 +159,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         super.onPause()
         when (Prefs.enableReopenPreviousRoomSessions) {
             true -> saveCurrentSession()
-            false -> initPreviousSessionPrefs()
+            false -> Prefs.initPreviousSessionPrefs()
         }
     }
 
@@ -193,7 +192,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         if (previousItem < 0) return
 
         binding.sessionsViewPager.currentItem = previousItem
-        initPreviousSessionPrefs()
+        Prefs.initPreviousSessionPrefs()
     }
 
     override val tagForFinding = MainActivity.BottomNavigationItem.SESSION.name

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -111,12 +111,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
                 .get(SessionsViewModel::class.java)
 
         if (Prefs.enableReopenPreviousRoomSessions and (savedInstanceState == null)) {
-            when (Prefs.previousSessionTab) {
-                SessionTabMode.SCHEDULE.name ->
-                    sessionsViewModel.changeTabMode(SessionTabMode.SCHEDULE)
-                else ->
-                    sessionsViewModel.changeTabMode(SessionTabMode.ROOM)
-            }
+            sessionsViewModel.changeTabMode(Prefs.previousSessionTab)
         }
 
         val progressTimeLatch = ProgressTimeLatch {
@@ -172,7 +167,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
     private fun saveCurrentSession() {
         val currentItem = binding.sessionsViewPager.currentItem
         Prefs.previousSessionTabId = currentItem
-        Prefs.previousSessionTab = sessionsViewModel.tabMode.name
+        Prefs.previousSessionTab = sessionsViewModel.tabMode
     }
 
     override fun onReselected() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/ContextExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/ContextExt.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import android.support.annotation.BoolRes
 import android.support.annotation.ColorRes
 import android.support.annotation.DrawableRes
+import android.support.annotation.IntegerRes
 import android.support.v4.content.ContextCompat
 import android.view.WindowManager
 
@@ -19,6 +20,8 @@ fun Context.displaySize(): Size {
 fun Context.color(@ColorRes color: Int): Int = ContextCompat.getColor(this, color)
 
 fun Context.bool(@BoolRes boolRes: Int): Boolean = resources.getBoolean(boolRes)
+
+fun Context.integer(@IntegerRes integerRes: Int): Int = resources.getInteger(integerRes)
 
 fun Context.drawable(@DrawableRes drawableRes: Int): Drawable {
     return ContextCompat.getDrawable(this, drawableRes)!!

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -80,6 +80,8 @@
     <string name="settings_enable_notification_summary_preference">このアプリで通知を受信するかどうかを選択できます。</string>
     <string name="settings_enable_hide_bottom_navigation_title_preference">BottomNavigationを隠す</string>
     <string name="settings_enable_hide_bottom_navigation_summary_preference">BottomNavigationBarをスクロールにあわせて隠すかどうかを選択できます。</string>
+    <string name="settings_enable_reopen_previous_room_sessions_title_preference">以前開いていたセッションリストを開く</string>
+    <string name="settings_enable_reopen_previous_room_sessions_summary_preference">最後に開いていたルーム及びセッションの場所を記録します。</string>
 
     <!-- Speaker -->
     <string name="speaker_title_activity_detail">スピーカー</string>

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -3,4 +3,5 @@
     <bool name="pref_default_value_enable_local_time">false</bool>
     <bool name="pref_default_value_enable_notification">true</bool>
     <bool name="pref_default_value_enable_hide_bottom_navigation">true</bool>
+    <bool name="pref_default_value_enable_reopen_previous_room_sessions">true</bool>
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="default_speakers_summary_layout_max_icon_count">5</integer>
+    <integer name="pref_default_value_previous_session_tab_id">-1</integer>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,8 +9,6 @@
     <string name="pref_key_enable_notification" translatable="false">pref_key_enable_notification</string>
     <string name="pref_key_enable_hide_bottom_navigation" translatable="false">pref_key_enable_hide_bottom_navigation</string>
     <string name="pref_key_enable_reopen_previous_room_sessions" translatable="false">pref_key_enable_reopen_previous_room_sessions</string>
-    <string name="pref_key_previous_session_tab" translatable="false">pref_key_previous_session_tab</string>
-    <string name="pref_key_previous_session_tab_id" translatable="false">pref_key_previous_session_tab_id</string>
 
     <!-- Preference Default Values -->
     <string name="pref_default_value_previous_session_tab" translatable="false">ROOM</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,12 @@
     <string name="pref_key_enable_local_time" translatable="false">pref_key_enable_local_time</string>
     <string name="pref_key_enable_notification" translatable="false">pref_key_enable_notification</string>
     <string name="pref_key_enable_hide_bottom_navigation" translatable="false">pref_key_enable_hide_bottom_navigation</string>
+    <string name="pref_key_enable_reopen_previous_room_sessions" translatable="false">pref_key_enable_reopen_previous_room_sessions</string>
+    <string name="pref_key_previous_session_tab" translatable="false">pref_key_previous_session_tab</string>
+    <string name="pref_key_previous_session_tab_id" translatable="false">pref_key_previous_session_tab_id</string>
+
+    <!-- Preference Default Values -->
+    <string name="pref_default_value_previous_session_tab" translatable="false">ROOM</string>
 
     <!-- NavigationDrawer -->
     <string name="nav_item_home">Home</string>
@@ -94,6 +100,10 @@
     <string name="settings_enable_hide_bottom_navigation_title_preference">Hide BottomNavigation</string>
     <string name="settings_enable_hide_bottom_navigation_summary_preference">Hide
         BottomNavigationBar by scrolling or not.</string>
+    <string name="settings_enable_reopen_previous_room_sessions_title_preference">Reopen previous
+        room sessions</string>
+    <string name="settings_enable_reopen_previous_room_sessions_summary_preference">Save the
+        room-tab and the sessions when closed.</string>
 
     <!-- Speaker -->
     <string name="speaker_title_activity_detail">Speaker</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,9 +10,6 @@
     <string name="pref_key_enable_hide_bottom_navigation" translatable="false">pref_key_enable_hide_bottom_navigation</string>
     <string name="pref_key_enable_reopen_previous_room_sessions" translatable="false">pref_key_enable_reopen_previous_room_sessions</string>
 
-    <!-- Preference Default Values -->
-    <string name="pref_default_value_previous_session_tab" translatable="false">ROOM</string>
-
     <!-- NavigationDrawer -->
     <string name="nav_item_home">Home</string>
     <string name="nav_item_map">Access</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -18,4 +18,10 @@
         android:summary="@string/settings_enable_hide_bottom_navigation_summary_preference"
         android:title="@string/settings_enable_hide_bottom_navigation_title_preference"
         />
+    <android.support.v7.preference.SwitchPreferenceCompat
+        android:defaultValue="@bool/pref_default_value_enable_reopen_previous_room_sessions"
+        android:key="@string/pref_key_enable_reopen_previous_room_sessions"
+        android:summary="@string/settings_enable_reopen_previous_room_sessions_summary_preference"
+        android:title="@string/settings_enable_reopen_previous_room_sessions_title_preference"
+        />
 </PreferenceScreen>

--- a/versions.gradle
+++ b/versions.gradle
@@ -102,6 +102,7 @@ ext {
             kotpref                : [
                     kotpref    : "com.chibatching.kotpref:kotpref:$versions.kotpref",
                     initializer: "com.chibatching.kotpref:initializer:$versions.kotpref",
+                    enumSupport: "com.chibatching.kotpref:enum-support:$versions.kotpref",
             ],
 
             //==================== UI ====================


### PR DESCRIPTION
## Issue
- Related to #353

## Overview (Required)
- When users open the session tab, reselect the previous tab mode, and reopen the previous session tab.
- Users can set the feature to enabled or disabled.

## Screenshot
setting off | setting on
:--: | :--:
![save_tabs_off](https://user-images.githubusercontent.com/26807657/35779180-477ce650-0a0c-11e8-8c5e-cdc2b977f392.gif) | ![save_tabs_on](https://user-images.githubusercontent.com/26807657/35779247-3890a8f6-0a0d-11e8-97c8-ca1498810ad2.gif)

