### PR TITLE
Fix like icon position(vertical position) on search page

### DIFF
--- a/app/src/main/res/layout/item_horizontal_session.xml
+++ b/app/src/main/res/layout/item_horizontal_session.xml
@@ -102,7 +102,7 @@
                 android:id="@+id/speakers"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                tools:layout_height="70dp"
+                tools:layout_height="68dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/favorite"
                 app:layout_constraintStart_toStartOf="parent"
@@ -113,12 +113,12 @@
 
             <io.github.droidkaigi.confsched2018.presentation.common.view.FavoriteButton
                 android:id="@+id/favorite"
+                android:layout_height="68dp"
                 style="@style/FavoriteButton"
                 android:checked="@{session.isFavorited}"
                 app:checkedColorTint="@color/accent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/title"
                 app:uncheckedColorTint="@color/sub_icon_color"
                 />
 


### PR DESCRIPTION
## Overview (Required)
Sorry... my previous PR had one lack of consideration...
If the session has 2 or 3 speakers, like icon moves up.
It's better to place like icon at same place on every session card.
So I changed to align it to most bottom speaker vertically in this PR.

// Each speaker icon size is 28dp.
// it has 4dp margins
// and speakers area has 16dp top/bottom mergines
// 28 + 4 * 2 + 16 * 2 = 68dp

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/10704349/35779067-b673c1ac-0a0a-11e8-8273-73891af8212c.png" width="300" /> | <img src="https://user-images.githubusercontent.com/10704349/35779068-b8fbba1a-0a0a-11e8-9792-3afcee4bdee8.png" width="300" />