### PR TITLE
Save tab and scroll position which is shown before.(part 2)

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -1,11 +1,8 @@
 package io.github.droidkaigi.confsched2018.presentation.common.pref
 
 import com.chibatching.kotpref.KotprefModel
-import com.chibatching.kotpref.enumpref.enumValuePref
 import io.github.droidkaigi.confsched2018.R
-import io.github.droidkaigi.confsched2018.presentation.sessions.SessionTabMode
 import io.github.droidkaigi.confsched2018.util.ext.bool
-import io.github.droidkaigi.confsched2018.util.ext.integer
 
 object Prefs : KotprefModel() {
     public override val kotprefName: String = "droidkaigi_prefs"
@@ -25,24 +22,4 @@ object Prefs : KotprefModel() {
             default = context.bool(R.bool.pref_default_value_enable_reopen_previous_room_sessions),
             key = R.string.pref_key_enable_reopen_previous_room_sessions
     )
-    var previousSessionTabMode by enumValuePref(SessionTabMode.ROOM)
-    var previousSessionTabId: Int by intPref(
-            default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
-    )
-    var previousSessionScrollPosition: Int by intPref(
-            default = context.integer(R.integer.pref_default_value_previous_session_scroll_position)
-    )
-    var previousSessionScrollOffset: Int by intPref(
-            default = context.integer(R.integer.pref_default_value_previous_session_scroll_offset)
-    )
-
-    fun initPreviousSessionPrefs() {
-        Prefs.previousSessionTabMode = SessionTabMode.ROOM
-        Prefs.previousSessionTabId = Prefs.context.integer(
-                integerRes = R.integer.pref_default_value_previous_session_tab_id)
-        Prefs.previousSessionScrollPosition = Prefs.context.integer(
-                integerRes = R.integer.pref_default_value_previous_session_scroll_position)
-        Prefs.previousSessionScrollOffset = Prefs.context.integer(
-                integerRes = R.integer.pref_default_value_previous_session_scroll_offset)
-    }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/Prefs.kt
@@ -29,10 +29,20 @@ object Prefs : KotprefModel() {
     var previousSessionTabId: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
+    var previousSessionScrollPosition: Int by intPref(
+            default = context.integer(R.integer.pref_default_value_previous_session_scroll_position)
+    )
+    var previousSessionScrollOffset: Int by intPref(
+            default = context.integer(R.integer.pref_default_value_previous_session_scroll_offset)
+    )
 
     fun initPreviousSessionPrefs() {
         Prefs.previousSessionTabMode = SessionTabMode.ROOM
         Prefs.previousSessionTabId = Prefs.context.integer(
                 integerRes = R.integer.pref_default_value_previous_session_tab_id)
+        Prefs.previousSessionScrollPosition = Prefs.context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_scroll_position)
+        Prefs.previousSessionScrollOffset = Prefs.context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_scroll_offset)
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/PreviousSessionPrefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/PreviousSessionPrefs.kt
@@ -1,0 +1,33 @@
+package io.github.droidkaigi.confsched2018.presentation.common.pref
+
+import com.chibatching.kotpref.KotprefModel
+import com.chibatching.kotpref.enumpref.enumValuePref
+import io.github.droidkaigi.confsched2018.R
+import io.github.droidkaigi.confsched2018.presentation.sessions.SessionTabMode
+import io.github.droidkaigi.confsched2018.util.ext.integer
+
+object PreviousSessionPrefs : KotprefModel() {
+    public override val kotprefName: String = "previous_session_prefs"
+    var previousSessionTabMode by enumValuePref(
+            default = SessionTabMode.ROOM
+    )
+    var previousSessionTabId: Int by intPref(
+            default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
+    )
+    var previousSessionScrollPosition: Int by intPref(
+            default = context.integer(R.integer.pref_default_value_previous_session_scroll_position)
+    )
+    var previousSessionScrollOffset: Int by intPref(
+            default = context.integer(R.integer.pref_default_value_previous_session_scroll_offset)
+    )
+
+    fun initPreviousSessionPrefs() {
+        PreviousSessionPrefs.previousSessionTabMode = SessionTabMode.ROOM
+        PreviousSessionPrefs.previousSessionTabId = context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_tab_id)
+        PreviousSessionPrefs.previousSessionScrollPosition = context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_scroll_position)
+        PreviousSessionPrefs.previousSessionScrollOffset = context.integer(
+                integerRes = R.integer.pref_default_value_previous_session_scroll_offset)
+    }
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/PreviousSessionPrefs.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/pref/PreviousSessionPrefs.kt
@@ -4,6 +4,7 @@ import com.chibatching.kotpref.KotprefModel
 import com.chibatching.kotpref.enumpref.enumValuePref
 import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionTabMode
+import io.github.droidkaigi.confsched2018.util.ext.ScrollState
 import io.github.droidkaigi.confsched2018.util.ext.integer
 
 object PreviousSessionPrefs : KotprefModel() {
@@ -14,10 +15,10 @@ object PreviousSessionPrefs : KotprefModel() {
     var previousSessionTabId: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_tab_id)
     )
-    var previousSessionScrollPosition: Int by intPref(
+    private var previousSessionScrollPosition: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_scroll_position)
     )
-    var previousSessionScrollOffset: Int by intPref(
+    private var previousSessionScrollOffset: Int by intPref(
             default = context.integer(R.integer.pref_default_value_previous_session_scroll_offset)
     )
 
@@ -30,4 +31,13 @@ object PreviousSessionPrefs : KotprefModel() {
         PreviousSessionPrefs.previousSessionScrollOffset = context.integer(
                 integerRes = R.integer.pref_default_value_previous_session_scroll_offset)
     }
+
+    var scrollState: ScrollState
+        get() = ScrollState(
+                anchorPosition = previousSessionScrollPosition,
+                anchorOffset = previousSessionScrollOffset)
+        set(scrollState) {
+            previousSessionScrollPosition = scrollState.anchorPosition
+            previousSessionScrollOffset = scrollState.anchorOffset
+        }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -120,9 +120,7 @@ class AllSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = layoutManager.getScrollState()
-        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
-        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.scrollState = layoutManager.getScrollState()
     }
 
     override fun restorePreviousSession() {
@@ -134,9 +132,10 @@ class AllSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        val scrollState = PreviousSessionPrefs.scrollState
         layoutManager.restoreScrollState(
-                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
-                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+                anchorPosition = scrollState.anchorPosition,
+                anchorOffset = scrollState.anchorOffset)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -29,10 +29,10 @@ import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessi
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
+import io.github.droidkaigi.confsched2018.util.ext.getScrollState
 import io.github.droidkaigi.confsched2018.util.ext.isGone
 import io.github.droidkaigi.confsched2018.util.ext.observe
-import io.github.droidkaigi.confsched2018.util.ext.restoreScrollPositionFromPrefs
-import io.github.droidkaigi.confsched2018.util.ext.saveScrollPositionToPrefs
+import io.github.droidkaigi.confsched2018.util.ext.restoreScrollState
 import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import io.github.droidkaigi.confsched2018.util.ext.setTextIfChanged
 import io.github.droidkaigi.confsched2018.util.ext.setVisible
@@ -120,7 +120,9 @@ class AllSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.saveScrollPositionToPrefs()
+        val scrollState = layoutManager.getScrollState()
+        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
+        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -132,7 +134,9 @@ class AllSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.restoreScrollPositionFromPrefs()
+        layoutManager.restoreScrollState(
+                anchorPosition = Prefs.previousSessionScrollPosition,
+                anchorOffset = Prefs.previousSessionScrollOffset)
         Prefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -20,8 +20,10 @@ import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedListener
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
+import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.SavePreviousSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.DateSessionsSection
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
@@ -29,6 +31,8 @@ import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
 import io.github.droidkaigi.confsched2018.util.ext.isGone
 import io.github.droidkaigi.confsched2018.util.ext.observe
+import io.github.droidkaigi.confsched2018.util.ext.restoreScrollPositionFromPrefs
+import io.github.droidkaigi.confsched2018.util.ext.saveScrollPositionToPrefs
 import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import io.github.droidkaigi.confsched2018.util.ext.setTextIfChanged
 import io.github.droidkaigi.confsched2018.util.ext.setVisible
@@ -42,7 +46,8 @@ class AllSessionsFragment :
         Fragment(),
         Injectable,
         CurrentSessionScroller,
-        OnTabReselectedListener {
+        OnTabReselectedListener,
+        SavePreviousSessionScroller {
 
     private lateinit var binding: FragmentAllSessionsBinding
 
@@ -111,6 +116,24 @@ class AllSessionsFragment :
 
     override fun onTabReselected() {
         binding.sessionsRecycler.smoothScrollToPosition(0)
+    }
+
+    override fun saveCurrentSession() {
+        val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        layoutManager.saveScrollPositionToPrefs()
+    }
+
+    override fun restorePreviousSession() {
+        sessionsViewModel.reopenPreviousSession.observe(this, {
+            if (it != true) return@observe
+            scrollToPreviousSession()
+        })
+    }
+
+    private fun scrollToPreviousSession() {
+        val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        layoutManager.restoreScrollPositionFromPrefs()
+        Prefs.initPreviousSessionPrefs()
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -91,7 +91,10 @@ class AllSessionsFragment :
                     sessionsSection.updateSessions(sessions, onFavoriteClickListener,
                             onFeedbackListener, true)
 
-                    sessionsViewModel.onSuccessFetchSessions()
+                    sessionsViewModel.onShowSessions()
+                    if (sessionsViewModel.isNeedRestoreScrollState) {
+                        scrollToPreviousSession()
+                    }
                 }
                 is Result.Failure -> {
                     Timber.e(result.e)
@@ -118,19 +121,21 @@ class AllSessionsFragment :
         binding.sessionsRecycler.smoothScrollToPosition(0)
     }
 
-    override fun saveCurrentSession() {
+    override fun requestSavingScrollState() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         PreviousSessionPrefs.scrollState = layoutManager.getScrollState()
     }
 
-    override fun restorePreviousSession() {
-        sessionsViewModel.reopenPreviousSession.observe(this, {
-            if (it != true) return@observe
+    override fun requestRestoringScrollState() {
+        if (sessionsViewModel.sessions is Result.Success<*>) {
             scrollToPreviousSession()
-        })
+        } else {
+            sessionsViewModel.isNeedRestoreScrollState = true
+        }
     }
 
     private fun scrollToPreviousSession() {
+        sessionsViewModel.isNeedRestoreScrollState = false
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -132,10 +132,7 @@ class AllSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = PreviousSessionPrefs.scrollState
-        layoutManager.restoreScrollState(
-                anchorPosition = scrollState.anchorPosition,
-                anchorOffset = scrollState.anchorOffset)
+        layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -20,7 +20,7 @@ import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
-import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+import io.github.droidkaigi.confsched2018.presentation.common.pref.PreviousSessionPrefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedListener
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.SavePreviousSessionScroller
@@ -121,8 +121,8 @@ class AllSessionsFragment :
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         val scrollState = layoutManager.getScrollState()
-        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
-        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
+        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -135,9 +135,9 @@ class AllSessionsFragment :
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(
-                anchorPosition = Prefs.previousSessionScrollPosition,
-                anchorOffset = Prefs.previousSessionScrollOffset)
-        Prefs.initPreviousSessionPrefs()
+                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
+                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+        PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
@@ -26,6 +26,9 @@ class AllSessionsViewModel @Inject constructor(
     private val focusCurrentSession: MutableLiveData<Boolean> = MutableLiveData()
     val refreshFocusCurrentSession: LiveData<Boolean> = focusCurrentSession
 
+    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
+    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+
     val sessions: LiveData<Result<List<Session>>> by lazy {
         repository.sessions
                 .toResult(schedulerProvider)
@@ -45,11 +48,18 @@ class AllSessionsViewModel @Inject constructor(
 
     fun onSuccessFetchSessions() {
         refreshFocusCurrentSession()
+        reopenPreviousSession()
     }
 
     private fun refreshFocusCurrentSession() {
         if (focusCurrentSession.value != true) {
             focusCurrentSession.value = true
+        }
+    }
+
+    private fun reopenPreviousSession() {
+        if (restorePreviousSession.value != true) {
+            restorePreviousSession.value = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsViewModel.kt
@@ -26,8 +26,7 @@ class AllSessionsViewModel @Inject constructor(
     private val focusCurrentSession: MutableLiveData<Boolean> = MutableLiveData()
     val refreshFocusCurrentSession: LiveData<Boolean> = focusCurrentSession
 
-    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
-    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+    var isNeedRestoreScrollState: Boolean = false
 
     val sessions: LiveData<Result<List<Session>>> by lazy {
         repository.sessions
@@ -46,20 +45,13 @@ class AllSessionsViewModel @Inject constructor(
                 .addTo(compositeDisposable)
     }
 
-    fun onSuccessFetchSessions() {
+    fun onShowSessions() {
         refreshFocusCurrentSession()
-        reopenPreviousSession()
     }
 
     private fun refreshFocusCurrentSession() {
         if (focusCurrentSession.value != true) {
             focusCurrentSession.value = true
-        }
-    }
-
-    private fun reopenPreviousSession() {
-        if (restorePreviousSession.value != true) {
-            restorePreviousSession.value = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -21,8 +21,10 @@ import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
+import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedListener
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
+import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.SavePreviousSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.DateSessionsSection
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
@@ -30,6 +32,8 @@ import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
 import io.github.droidkaigi.confsched2018.util.ext.isGone
 import io.github.droidkaigi.confsched2018.util.ext.observe
+import io.github.droidkaigi.confsched2018.util.ext.restoreScrollPositionFromPrefs
+import io.github.droidkaigi.confsched2018.util.ext.saveScrollPositionToPrefs
 import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import io.github.droidkaigi.confsched2018.util.ext.setTextIfChanged
 import io.github.droidkaigi.confsched2018.util.ext.setVisible
@@ -43,7 +47,8 @@ class RoomSessionsFragment :
         Fragment(),
         Injectable,
         CurrentSessionScroller,
-        OnTabReselectedListener {
+        OnTabReselectedListener,
+        SavePreviousSessionScroller {
 
     private lateinit var binding: FragmentRoomSessionsBinding
     private lateinit var roomName: String
@@ -119,6 +124,24 @@ class RoomSessionsFragment :
 
     override fun onTabReselected() {
         binding.sessionsRecycler.smoothScrollToPosition(0)
+    }
+
+    override fun saveCurrentSession() {
+        val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        layoutManager.saveScrollPositionToPrefs()
+    }
+
+    override fun restorePreviousSession() {
+        sessionsViewModel.reopenPreviousSession.observe(this, {
+            if (it != true) return@observe
+            scrollToPreviousSession()
+        })
+    }
+
+    private fun scrollToPreviousSession() {
+        val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        layoutManager.restoreScrollPositionFromPrefs()
+        Prefs.initPreviousSessionPrefs()
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -140,10 +140,7 @@ class RoomSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = PreviousSessionPrefs.scrollState
-        layoutManager.restoreScrollState(
-                anchorPosition = scrollState.anchorPosition,
-                anchorOffset = scrollState.anchorOffset)
+        layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -21,7 +21,7 @@ import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
-import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+import io.github.droidkaigi.confsched2018.presentation.common.pref.PreviousSessionPrefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedListener
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.CurrentSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.SavePreviousSessionScroller
@@ -129,8 +129,8 @@ class RoomSessionsFragment :
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         val scrollState = layoutManager.getScrollState()
-        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
-        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
+        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -143,9 +143,9 @@ class RoomSessionsFragment :
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(
-                anchorPosition = Prefs.previousSessionScrollPosition,
-                anchorOffset = Prefs.previousSessionScrollOffset)
-        Prefs.initPreviousSessionPrefs()
+                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
+                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+        PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 
     private fun setupRecyclerView() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -128,9 +128,7 @@ class RoomSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = layoutManager.getScrollState()
-        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
-        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.scrollState = layoutManager.getScrollState()
     }
 
     override fun restorePreviousSession() {
@@ -142,9 +140,10 @@ class RoomSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        val scrollState = PreviousSessionPrefs.scrollState
         layoutManager.restoreScrollState(
-                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
-                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+                anchorPosition = scrollState.anchorPosition,
+                anchorOffset = scrollState.anchorOffset)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -99,7 +99,10 @@ class RoomSessionsFragment :
                     sessionsSection.updateSessions(sessions, onFavoriteClickListener,
                             onFeedbackListener, true)
 
-                    sessionsViewModel.onSuccessFetchSessions()
+                    sessionsViewModel.onShowSessions()
+                    if (sessionsViewModel.isNeedRestoreScrollState) {
+                        scrollToPreviousSession()
+                    }
                 }
                 is Result.Failure -> {
                     Timber.e(result.e)
@@ -126,19 +129,21 @@ class RoomSessionsFragment :
         binding.sessionsRecycler.smoothScrollToPosition(0)
     }
 
-    override fun saveCurrentSession() {
+    override fun requestSavingScrollState() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         PreviousSessionPrefs.scrollState = layoutManager.getScrollState()
     }
 
-    override fun restorePreviousSession() {
-        sessionsViewModel.reopenPreviousSession.observe(this, {
-            if (it != true) return@observe
+    override fun requestRestoringScrollState() {
+        if (sessionsViewModel.sessions is Result.Success<*>) {
             scrollToPreviousSession()
-        })
+        } else {
+            sessionsViewModel.isNeedRestoreScrollState = true
+        }
     }
 
     private fun scrollToPreviousSession() {
+        sessionsViewModel.isNeedRestoreScrollState = false
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -30,10 +30,10 @@ import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessi
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
 import io.github.droidkaigi.confsched2018.util.ext.addOnScrollListener
+import io.github.droidkaigi.confsched2018.util.ext.getScrollState
 import io.github.droidkaigi.confsched2018.util.ext.isGone
 import io.github.droidkaigi.confsched2018.util.ext.observe
-import io.github.droidkaigi.confsched2018.util.ext.restoreScrollPositionFromPrefs
-import io.github.droidkaigi.confsched2018.util.ext.saveScrollPositionToPrefs
+import io.github.droidkaigi.confsched2018.util.ext.restoreScrollState
 import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import io.github.droidkaigi.confsched2018.util.ext.setTextIfChanged
 import io.github.droidkaigi.confsched2018.util.ext.setVisible
@@ -128,7 +128,9 @@ class RoomSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.saveScrollPositionToPrefs()
+        val scrollState = layoutManager.getScrollState()
+        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
+        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -140,7 +142,9 @@ class RoomSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.restoreScrollPositionFromPrefs()
+        layoutManager.restoreScrollState(
+                anchorPosition = Prefs.previousSessionScrollPosition,
+                anchorOffset = Prefs.previousSessionScrollOffset)
         Prefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
@@ -26,6 +26,10 @@ class RoomSessionsViewModel @Inject constructor(
 
     private val focusCurrentSession: MutableLiveData<Boolean> = MutableLiveData()
     val refreshFocusCurrentSession: LiveData<Boolean> = focusCurrentSession
+
+    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
+    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+
     lateinit var roomName: String
 
     val sessions: LiveData<Result<List<Session>>> by lazy {
@@ -49,11 +53,18 @@ class RoomSessionsViewModel @Inject constructor(
 
     fun onSuccessFetchSessions() {
         refreshFocusCurrentSession()
+        reopenPreviousSession()
     }
 
     private fun refreshFocusCurrentSession() {
         if (focusCurrentSession.value != true) {
             focusCurrentSession.value = true
+        }
+    }
+
+    private fun reopenPreviousSession() {
+        if (restorePreviousSession.value != true) {
+            restorePreviousSession.value = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsViewModel.kt
@@ -27,8 +27,7 @@ class RoomSessionsViewModel @Inject constructor(
     private val focusCurrentSession: MutableLiveData<Boolean> = MutableLiveData()
     val refreshFocusCurrentSession: LiveData<Boolean> = focusCurrentSession
 
-    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
-    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+    var isNeedRestoreScrollState: Boolean = false
 
     lateinit var roomName: String
 
@@ -51,20 +50,13 @@ class RoomSessionsViewModel @Inject constructor(
                 .addTo(compositeDisposable)
     }
 
-    fun onSuccessFetchSessions() {
+    fun onShowSessions() {
         refreshFocusCurrentSession()
-        reopenPreviousSession()
     }
 
     private fun refreshFocusCurrentSession() {
         if (focusCurrentSession.value != true) {
             focusCurrentSession.value = true
-        }
-    }
-
-    private fun reopenPreviousSession() {
-        if (restorePreviousSession.value != true) {
-            restorePreviousSession.value = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -18,7 +18,7 @@ import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.model.SessionSchedule
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
 import io.github.droidkaigi.confsched2018.presentation.Result
-import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+import io.github.droidkaigi.confsched2018.presentation.common.pref.PreviousSessionPrefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedListener
 import io.github.droidkaigi.confsched2018.presentation.sessions.SessionsFragment.SavePreviousSessionScroller
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.ScheduleSessionsSection
@@ -121,8 +121,8 @@ class ScheduleSessionsFragment :
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         val scrollState = layoutManager.getScrollState()
-        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
-        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
+        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -135,9 +135,9 @@ class ScheduleSessionsFragment :
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(
-                anchorPosition = Prefs.previousSessionScrollPosition,
-                anchorOffset = Prefs.previousSessionScrollOffset)
-        Prefs.initPreviousSessionPrefs()
+                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
+                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+        PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 
     companion object {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -25,9 +25,9 @@ import io.github.droidkaigi.confsched2018.presentation.sessions.item.ScheduleSes
 import io.github.droidkaigi.confsched2018.presentation.sessions.item.SpeechSessionItem
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.SessionAlarm
+import io.github.droidkaigi.confsched2018.util.ext.getScrollState
 import io.github.droidkaigi.confsched2018.util.ext.observe
-import io.github.droidkaigi.confsched2018.util.ext.restoreScrollPositionFromPrefs
-import io.github.droidkaigi.confsched2018.util.ext.saveScrollPositionToPrefs
+import io.github.droidkaigi.confsched2018.util.ext.restoreScrollState
 import io.github.droidkaigi.confsched2018.util.ext.setLinearDivider
 import timber.log.Timber
 import javax.inject.Inject
@@ -120,7 +120,9 @@ class ScheduleSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.saveScrollPositionToPrefs()
+        val scrollState = layoutManager.getScrollState()
+        Prefs.previousSessionScrollPosition = scrollState.anchorPosition
+        Prefs.previousSessionScrollOffset = scrollState.anchorOffset
     }
 
     override fun restorePreviousSession() {
@@ -132,7 +134,9 @@ class ScheduleSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        layoutManager.restoreScrollPositionFromPrefs()
+        layoutManager.restoreScrollState(
+                anchorPosition = Prefs.previousSessionScrollPosition,
+                anchorOffset = Prefs.previousSessionScrollOffset)
         Prefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -120,9 +120,7 @@ class ScheduleSessionsFragment :
 
     override fun saveCurrentSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = layoutManager.getScrollState()
-        PreviousSessionPrefs.previousSessionScrollPosition = scrollState.anchorPosition
-        PreviousSessionPrefs.previousSessionScrollOffset = scrollState.anchorOffset
+        PreviousSessionPrefs.scrollState = layoutManager.getScrollState()
     }
 
     override fun restorePreviousSession() {
@@ -134,9 +132,10 @@ class ScheduleSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
+        val scrollState = PreviousSessionPrefs.scrollState
         layoutManager.restoreScrollState(
-                anchorPosition = PreviousSessionPrefs.previousSessionScrollPosition,
-                anchorOffset = PreviousSessionPrefs.previousSessionScrollOffset)
+                anchorPosition = scrollState.anchorPosition,
+                anchorOffset = scrollState.anchorOffset)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -132,10 +132,7 @@ class ScheduleSessionsFragment :
 
     private fun scrollToPreviousSession() {
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
-        val scrollState = PreviousSessionPrefs.scrollState
-        layoutManager.restoreScrollState(
-                anchorPosition = scrollState.anchorPosition,
-                anchorOffset = scrollState.anchorOffset)
+        layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsViewModel.kt
@@ -1,7 +1,6 @@
 package io.github.droidkaigi.confsched2018.presentation.sessions
 
 import android.arch.lifecycle.LiveData
-import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2018.model.Session
@@ -26,8 +25,7 @@ class ScheduleSessionsViewModel @Inject constructor(
 
     lateinit var schedule: SessionSchedule
 
-    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
-    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+    var isNeedRestoreScrollState: Boolean = false
 
     val sessions: LiveData<Result<List<Session>>> by lazy {
         repository.scheduleSessions
@@ -46,16 +44,6 @@ class ScheduleSessionsViewModel @Inject constructor(
         favoriteSingle
                 .subscribeBy(onError = defaultErrorHandler())
                 .addTo(compositeDisposable)
-    }
-
-    fun onSuccessFetchSessions() {
-        reopenPreviousSession()
-    }
-
-    private fun reopenPreviousSession() {
-        if (restorePreviousSession.value != true) {
-            restorePreviousSession.value = true
-        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsViewModel.kt
@@ -1,6 +1,7 @@
 package io.github.droidkaigi.confsched2018.presentation.sessions
 
 import android.arch.lifecycle.LiveData
+import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2018.model.Session
@@ -25,6 +26,9 @@ class ScheduleSessionsViewModel @Inject constructor(
 
     lateinit var schedule: SessionSchedule
 
+    private val restorePreviousSession: MutableLiveData<Boolean> = MutableLiveData()
+    val reopenPreviousSession: LiveData<Boolean> = restorePreviousSession
+
     val sessions: LiveData<Result<List<Session>>> by lazy {
         repository.scheduleSessions
                 .map { t: Map<SessionSchedule, List<Session>> ->
@@ -42,6 +46,16 @@ class ScheduleSessionsViewModel @Inject constructor(
         favoriteSingle
                 .subscribeBy(onError = defaultErrorHandler())
                 .addTo(compositeDisposable)
+    }
+
+    fun onSuccessFetchSessions() {
+        reopenPreviousSession()
+    }
+
+    private fun reopenPreviousSession() {
+        if (restorePreviousSession.value != true) {
+            restorePreviousSession.value = true
+        }
     }
 
     override fun onCleared() {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -27,6 +27,7 @@ import io.github.droidkaigi.confsched2018.presentation.MainActivity.BottomNaviga
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.common.fragment.Findable
 import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+import io.github.droidkaigi.confsched2018.presentation.common.pref.PreviousSessionPrefs
 import io.github.droidkaigi.confsched2018.presentation.common.view.OnTabReselectedDispatcher
 import io.github.droidkaigi.confsched2018.util.ProgressTimeLatch
 import io.github.droidkaigi.confsched2018.util.ext.observe
@@ -110,7 +111,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
                 .get(SessionsViewModel::class.java)
 
         if (Prefs.enableReopenPreviousRoomSessions and (savedInstanceState == null)) {
-            sessionsViewModel.changeTabMode(Prefs.previousSessionTabMode)
+            sessionsViewModel.changeTabMode(PreviousSessionPrefs.previousSessionTabMode)
         }
 
         val progressTimeLatch = ProgressTimeLatch {
@@ -159,14 +160,14 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         super.onPause()
         when (Prefs.enableReopenPreviousRoomSessions) {
             true -> saveCurrentSession()
-            false -> Prefs.initPreviousSessionPrefs()
+            false -> PreviousSessionPrefs.initPreviousSessionPrefs()
         }
     }
 
     private fun saveCurrentSession() {
         val currentItem = binding.sessionsViewPager.currentItem
-        Prefs.previousSessionTabId = currentItem
-        Prefs.previousSessionTabMode = sessionsViewModel.tabMode
+        PreviousSessionPrefs.previousSessionTabId = currentItem
+        PreviousSessionPrefs.previousSessionTabMode = sessionsViewModel.tabMode
         val fragment = sessionsViewPagerAdapter
                 .instantiateItem(binding.sessionsViewPager, currentItem)
         if (fragment is SavePreviousSessionScroller) {
@@ -193,7 +194,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
     }
 
     private fun reopenPreviousOpenedItem() {
-        val previousItem = Prefs.previousSessionTabId
+        val previousItem = PreviousSessionPrefs.previousSessionTabId
         if (previousItem < 0) return
 
         binding.sessionsViewPager.currentItem = previousItem

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -171,7 +171,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         val fragment = sessionsViewPagerAdapter
                 .instantiateItem(binding.sessionsViewPager, currentItem)
         if (fragment is SavePreviousSessionScroller) {
-            fragment.saveCurrentSession()
+            fragment.requestSavingScrollState()
         }
     }
 
@@ -201,7 +201,7 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         val fragment = sessionsViewPagerAdapter
                 .instantiateItem(binding.sessionsViewPager, previousItem)
         if (fragment is SavePreviousSessionScroller) {
-            fragment.restorePreviousSession()
+            fragment.requestRestoringScrollState()
         }
     }
 
@@ -212,8 +212,8 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
     }
 
     interface SavePreviousSessionScroller {
-        fun saveCurrentSession()
-        fun restorePreviousSession()
+        fun requestSavingScrollState()
+        fun requestRestoringScrollState()
     }
 
     companion object {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -167,6 +167,11 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         val currentItem = binding.sessionsViewPager.currentItem
         Prefs.previousSessionTabId = currentItem
         Prefs.previousSessionTabMode = sessionsViewModel.tabMode
+        val fragment = sessionsViewPagerAdapter
+                .instantiateItem(binding.sessionsViewPager, currentItem)
+        if (fragment is SavePreviousSessionScroller) {
+            fragment.saveCurrentSession()
+        }
     }
 
     override fun onReselected() {
@@ -192,13 +197,22 @@ class SessionsFragment : Fragment(), Injectable, Findable, OnReselectedListener 
         if (previousItem < 0) return
 
         binding.sessionsViewPager.currentItem = previousItem
-        Prefs.initPreviousSessionPrefs()
+        val fragment = sessionsViewPagerAdapter
+                .instantiateItem(binding.sessionsViewPager, previousItem)
+        if (fragment is SavePreviousSessionScroller) {
+            fragment.restorePreviousSession()
+        }
     }
 
     override val tagForFinding = MainActivity.BottomNavigationItem.SESSION.name
 
     interface CurrentSessionScroller {
         fun scrollToCurrentSession()
+    }
+
+    interface SavePreviousSessionScroller {
+        fun saveCurrentSession()
+        fun restorePreviousSession()
     }
 
     companion object {

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
@@ -3,32 +3,27 @@ package io.github.droidkaigi.confsched2018.util.ext
 import android.os.Parcel
 import android.os.Parcelable
 import android.support.v7.widget.LinearLayoutManager
-import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
 
-fun LinearLayoutManager.saveScrollPositionToPrefs() {
+fun LinearLayoutManager.getScrollState(): ScrollState {
     val savedState = onSaveInstanceState()
     val parcel = Parcel.obtain()
     savedState.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE)
     parcel.setDataPosition(0)
 
-    val anchorPosition = parcel.readInt()
-    val anchorOffset = parcel.readInt()
-
+    val scrollState = ScrollState(
+            anchorPosition = parcel.readInt(),
+            anchorOffset = parcel.readInt())
     parcel.recycle()
 
-    Prefs.previousSessionScrollPosition = anchorPosition
-    Prefs.previousSessionScrollOffset = anchorOffset
+    return scrollState
 }
 
-fun LinearLayoutManager.restoreScrollPositionFromPrefs() {
-    val previousScrollPosition = Prefs.previousSessionScrollPosition
-    val previousScrollOffset = Prefs.previousSessionScrollOffset
-
-    if (previousScrollPosition < 0) return
+fun LinearLayoutManager.restoreScrollState(anchorPosition: Int, anchorOffset: Int) {
+    if (anchorPosition < 0) return
 
     val parcel = Parcel.obtain()
-    parcel.writeInt(previousScrollPosition)
-    parcel.writeInt(previousScrollOffset)
+    parcel.writeInt(anchorPosition)
+    parcel.writeInt(anchorOffset)
     parcel.writeInt(0)
     parcel.setDataPosition(0)
 
@@ -38,3 +33,5 @@ fun LinearLayoutManager.restoreScrollPositionFromPrefs() {
 
     onRestoreInstanceState(savedState)
 }
+
+class ScrollState(val anchorPosition: Int, val anchorOffset: Int)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
@@ -18,12 +18,12 @@ fun LinearLayoutManager.getScrollState(): ScrollState {
     return scrollState
 }
 
-fun LinearLayoutManager.restoreScrollState(anchorPosition: Int, anchorOffset: Int) {
-    if (anchorPosition < 0) return
+fun LinearLayoutManager.restoreScrollState(scrollState: ScrollState) {
+    if (scrollState.anchorPosition < 0) return
 
     val parcel = Parcel.obtain()
-    parcel.writeInt(anchorPosition)
-    parcel.writeInt(anchorOffset)
+    parcel.writeInt(scrollState.anchorPosition)
+    parcel.writeInt(scrollState.anchorOffset)
     parcel.writeInt(0)
     parcel.setDataPosition(0)
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/LinearLayoutManagerExt.kt
@@ -1,0 +1,40 @@
+package io.github.droidkaigi.confsched2018.util.ext
+
+import android.os.Parcel
+import android.os.Parcelable
+import android.support.v7.widget.LinearLayoutManager
+import io.github.droidkaigi.confsched2018.presentation.common.pref.Prefs
+
+fun LinearLayoutManager.saveScrollPositionToPrefs() {
+    val savedState = onSaveInstanceState()
+    val parcel = Parcel.obtain()
+    savedState.writeToParcel(parcel, Parcelable.PARCELABLE_WRITE_RETURN_VALUE)
+    parcel.setDataPosition(0)
+
+    val anchorPosition = parcel.readInt()
+    val anchorOffset = parcel.readInt()
+
+    parcel.recycle()
+
+    Prefs.previousSessionScrollPosition = anchorPosition
+    Prefs.previousSessionScrollOffset = anchorOffset
+}
+
+fun LinearLayoutManager.restoreScrollPositionFromPrefs() {
+    val previousScrollPosition = Prefs.previousSessionScrollPosition
+    val previousScrollOffset = Prefs.previousSessionScrollOffset
+
+    if (previousScrollPosition < 0) return
+
+    val parcel = Parcel.obtain()
+    parcel.writeInt(previousScrollPosition)
+    parcel.writeInt(previousScrollOffset)
+    parcel.writeInt(0)
+    parcel.setDataPosition(0)
+
+    val savedState = LinearLayoutManager.SavedState.CREATOR.createFromParcel(parcel)
+
+    parcel.recycle()
+
+    onRestoreInstanceState(savedState)
+}

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -2,4 +2,6 @@
 <resources>
     <integer name="default_speakers_summary_layout_max_icon_count">5</integer>
     <integer name="pref_default_value_previous_session_tab_id">-1</integer>
+    <integer name="pref_default_value_previous_session_scroll_position">-1</integer>
+    <integer name="pref_default_value_previous_session_scroll_offset">0</integer>
 </resources>


### PR DESCRIPTION
## Issue
- close #353

## Overview (Required)
- When users open the session tab, reopen the previous session tab **and restore scroll position**.
- This PR implements feature of **restore scroll position** .
- Move to `Prefs.initPreviousSessionPrefs()` to finishing restore scroll position.

## Links
- https://stackoverflow.com/questions/27816217/how-to-save-recyclerviews-scroll-position-using-recyclerview-state

## Screenshot
![save_tabs_and_scroll](https://user-images.githubusercontent.com/26807657/35781444-9169fcd2-0a2d-11e8-86c3-bf3693d5ea24.gif)

