### PR TITLE
Fix #599 Bottom Navigation will be never shown

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/MainActivity.kt
@@ -101,6 +101,7 @@ class MainActivity : BaseActivity(), HasSupportFragmentInjector {
     }
 
     private fun setBottomNavigationBehavior() {
+        binding.bottomNavigation.translationY = 0f
         (binding.bottomNavigation.layoutParams as CoordinatorLayout.LayoutParams).behavior =
                 if (Prefs.enableHideBottomNavigationBar) {
                     BottomNavigationHideBehavior()


### PR DESCRIPTION
## Issue
- close #599 

## Overview (Required)

The cause was due to the fact that the state of BottomNavigationView was not reset at the switching of the behavior.

## Screenshot
Before | After
:--: | :--:
![before](https://user-images.githubusercontent.com/26807657/35778090-9235fc3c-09fc-11e8-9450-2e2c81fb6dc4.gif) | ![ezgif-4-ba280b64a5](https://user-images.githubusercontent.com/7608725/35794285-81b27d30-0a98-11e8-80a1-06d75ec4d8ec.gif)
