### PR TITLE
Reload speaker recycler view due to the transition bug

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
@@ -210,6 +210,9 @@ class SpeakerDetailFragment : Fragment(), Injectable {
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private fun reveal() {
+        // reload recycler view
+        binding.sessionsRecycler.adapter.notifyDataSetChanged()
+
         val revealView = view?.findViewById<View>(R.id.app_bar_background) ?: return
         val speakerImage = view?.findViewById<View>(R.id.speaker_image) ?: return
         val cx = (speakerImage.x + speakerImage.width / 2).toInt()


### PR DESCRIPTION
## Issue
- refs #568 

## Overview (Required)
- **This is very ugly patch, so you should not merge this basically.**
- It seems that the `sessionsRecycler` is not reloaded during transition, so this patch notifies it on end of the transition
- I know #611 is already there. 

## Links
- none

## Screenshot
- none
