### PR TITLE
Changed SwipeRefesh color

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/ContributorsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/contributor/ContributorsFragment.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
+import io.github.droidkaigi.confsched2018.R
 import io.github.droidkaigi.confsched2018.databinding.FragmentContributorBinding
 import io.github.droidkaigi.confsched2018.di.Injectable
 import io.github.droidkaigi.confsched2018.presentation.NavigationController
@@ -72,13 +73,16 @@ class ContributorsFragment : Fragment(), Injectable {
     }
 
     private fun setupSwipeRefresh() {
-        binding.contributorsSwipeRefresh.setOnRefreshListener({
-            contributorsViewModel.onRefreshContributors()
+        binding.contributorsSwipeRefresh.apply {
+            setColorSchemeResources(R.color.accent)
+            setOnRefreshListener({
+                contributorsViewModel.onRefreshContributors()
 
-            if (binding.contributorsSwipeRefresh.isRefreshing) {
-                binding.contributorsSwipeRefresh.isRefreshing = false
-            }
-        })
+                if (binding.contributorsSwipeRefresh.isRefreshing) {
+                    binding.contributorsSwipeRefresh.isRefreshing = false
+                }
+            })
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Issue
- none

## Overview (Required)
- As it was different from the color of other ProgressBars, I had a sense of incompatibility. So I changed it like any other ProgressBar color.
- But If the previous color is a specification, please close this PR 🙇 
- In addition, SwipeRefreshLayout is used in Chrome Custom Tabs, and the color is different from other ProgressBar color, but I have no idea how to change it.

## Links
- none

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/1450486/35838634-a457e34c-0b2f-11e8-8a80-16ffdbcf28cd.png" width="300" /> | <img src="https://user-images.githubusercontent.com/1450486/35838642-b01a23ca-0b2f-11e8-9e47-d50b5ba49f6d.png" width="300" />



