### PR TITLE
Set big text style on notification not to omit long contents

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationHelper.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/notification/NotificationHelper.kt
@@ -50,8 +50,11 @@ fun Context.showNotification(
     NotificationManagerCompat.from(this).notify(
             content.text.hashCode(),
             NotificationCompat.Builder(this, content.channelType.id)
-                    .setContentTitle(content.title)
-                    .setContentText(content.text)
+                    .setStyle(
+                            NotificationCompat.BigTextStyle()
+                                    .setBigContentTitle(content.title)
+                                    .bigText(content.text)
+                    )
                     .setFullScreenIntent(content.createPendingContentIntent(this), true)
                     .setAutoCancel(true)
                     .setColor(ContextCompat.getColor(this, R.color.primary))

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/service/push/processor/NewPostProcessor.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/service/push/processor/NewPostProcessor.kt
@@ -44,8 +44,11 @@ class NewPostProcessor @Inject constructor(
         }
         val notification: Notification = NotificationCompat.Builder(application,
                 NotificationChannelType.NEW_FEED_POST.id)
-                .setContentTitle(title)
-                .setContentText(content)
+                .setStyle(
+                        NotificationCompat.BigTextStyle()
+                                .setBigContentTitle(title)
+                                .bigText(content)
+                )
                 .setAutoCancel(true)
                 .setLargeIcon((ContextCompat.getDrawable(application, largeIcon) as BitmapDrawable)
                         .bitmap)


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- Set BigText Style for notification 

## Links
- #624

## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/7427558/35857860-bdcde922-0b7d-11e8-9a8b-5f226db84e03.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7427558/35857858-bd7f893a-0b7d-11e8-9403-68a73e055f7f.png" width="300" />
<img src="https://user-images.githubusercontent.com/7427558/35857859-bda58aae-0b7d-11e8-8482-f98d107d31f9.png" width="300" /> | <img src="https://user-images.githubusercontent.com/7427558/35857855-bd59450e-0b7d-11e8-87a8-1f3b56ba7de7.png" width="300" />
