### PR TITLE
Revert "Move to current session tab when switching schedules screen"

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsFragment.kt
@@ -121,9 +121,6 @@ class SessionsFragment : DaggerFragment(), Findable, OnReselectedListener {
             when (result) {
                 is Result.Success -> {
                     sessionsViewPagerAdapter.setSessionTab(result.data)
-                    if (result.data is SessionTab.Schedule) {
-                        scrollToRecentScheduleTab()
-                    }
                     activity?.invalidateOptionsMenu()
                     if (Prefs.enableReopenPreviousRoomSessions and (savedInstanceState == null)) {
                         reopenPreviousOpenedItem()
@@ -194,14 +191,10 @@ class SessionsFragment : DaggerFragment(), Findable, OnReselectedListener {
                 }
             }
             SessionTabMode.SCHEDULE -> {
-                scrollToRecentScheduleTab()
+                val position = sessionsViewPagerAdapter.getRecentScheduleTabPosition()
+                binding.sessionsViewPager.currentItem = position
             }
         }
-    }
-
-    private fun scrollToRecentScheduleTab() {
-        val position = sessionsViewPagerAdapter.getRecentScheduleTabPosition()
-        binding.sessionsViewPager.currentItem = position
     }
 
     private fun reopenPreviousOpenedItem() {


### PR DESCRIPTION
Reverts DroidKaigi/conference-app-2018#627
This implementation will scroll to the tab of the current time when registering in favorites, so we will revert