### PR TITLE
Refactor to replace LocalDateTime into Instant.

### DIFF
--- a/app/src/androidTest/java/io/github/droidkaigi/confsched2018/test/data/api/StubDroidKaigiApi.kt
+++ b/app/src/androidTest/java/io/github/droidkaigi/confsched2018/test/data/api/StubDroidKaigiApi.kt
@@ -6,8 +6,9 @@ import io.github.droidkaigi.confsched2018.data.api.DroidKaigiApi
 import io.github.droidkaigi.confsched2018.data.api.response.Response
 import io.github.droidkaigi.confsched2018.data.api.response.SponsorPlan
 import io.github.droidkaigi.confsched2018.data.api.response.mapper.ApplicationJsonAdapterFactory
-import io.github.droidkaigi.confsched2018.data.api.response.mapper.LocalDateTimeAdapter
+import io.github.droidkaigi.confsched2018.data.api.response.mapper.InstantAdapter
 import io.reactivex.Single
+import org.threeten.bp.Instant
 import org.threeten.bp.LocalDateTime
 
 class StubDroidKaigiApi : DroidKaigiApi {
@@ -16,7 +17,7 @@ class StubDroidKaigiApi : DroidKaigiApi {
                 .bufferedReader().use { it.readText() }
         val moshi = Moshi.Builder()
                 .add(ApplicationJsonAdapterFactory.INSTANCE)
-                .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                .add(Instant::class.java, InstantAdapter())
                 .build()
         val adapter = moshi.adapter<Response>(Response::class.java)
         val response = adapter.fromJson(json)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/Session.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/Session.kt
@@ -1,6 +1,6 @@
 package io.github.droidkaigi.confsched2018.data.api.response
 
-import org.threeten.bp.LocalDateTime
+import org.threeten.bp.Instant
 import se.ansman.kotshi.JsonSerializable
 
 @JsonSerializable
@@ -10,9 +10,9 @@ data class Session(
         val isPlenumSession: Boolean?,
         val speakers: List<String?>?,
         val description: String?,
-        val startsAt: LocalDateTime?,
+        val startsAt: Instant?,
         val title: String?,
-        val endsAt: LocalDateTime?,
+        val endsAt: Instant?,
         val roomId: Int?,
         val categoryItems: List<Int?>?,
         val message: SessionMessage?

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/InstantAdapter.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/InstantAdapter.kt
@@ -3,19 +3,21 @@ package io.github.droidkaigi.confsched2018.data.api.response.mapper
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
+import io.github.droidkaigi.confsched2018.util.ext.atJST
+import org.threeten.bp.Instant
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.format.DateTimeFormatter
 
-class LocalDateTimeAdapter : JsonAdapter<LocalDateTime>() {
-    override fun toJson(writer: JsonWriter, value: LocalDateTime?) {
+class InstantAdapter : JsonAdapter<Instant>() {
+    override fun toJson(writer: JsonWriter, value: Instant?) {
         if (value == null) {
             writer.nullValue()
         } else {
-            writer.value(value.format(FORMATTER))
+            writer.value(value.atJST().format(FORMATTER))
         }
     }
 
-    override fun fromJson(reader: JsonReader): LocalDateTime? = when (reader.peek()) {
+    override fun fromJson(reader: JsonReader): Instant? = when (reader.peek()) {
         JsonReader.Token.NULL -> reader.nextNull()
         else -> {
             val dateString = reader.nextString()
@@ -26,7 +28,12 @@ class LocalDateTimeAdapter : JsonAdapter<LocalDateTime>() {
     companion object {
         private val FORMATTER: DateTimeFormatter =
                 DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
-        fun parseDateString(dateString: String?): LocalDateTime =
-                LocalDateTime.parse(dateString, FORMATTER)
+
+        /**
+         * Obtains an instance of Instant from a text string such as "2018-02-08T17:40:00".
+         * The string must represent in JST (GMT+9:00).
+         */
+        fun parseDateString(dateString: String?): Instant =
+                LocalDateTime.parse(dateString, FORMATTER).atJST().toInstant()
     }
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/SessionEntity.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/SessionEntity.kt
@@ -3,15 +3,15 @@ package io.github.droidkaigi.confsched2018.data.db.entity
 import android.arch.persistence.room.Embedded
 import android.arch.persistence.room.Entity
 import android.arch.persistence.room.PrimaryKey
-import org.threeten.bp.LocalDateTime
+import org.threeten.bp.Instant
 
 @Entity(tableName = "session")
 data class SessionEntity(
         @PrimaryKey var id: String,
         var title: String,
         var desc: String,
-        var stime: LocalDateTime,
-        var etime: LocalDateTime,
+        var stime: Instant,
+        var etime: Instant,
         var sessionFormat: String,
         var language: String,
         @Embedded var level: LevelEntity,

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/Converters.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/Converters.kt
@@ -3,24 +3,21 @@ package io.github.droidkaigi.confsched2018.data.db.entity.mapper
 import android.arch.persistence.room.TypeConverter
 import io.github.droidkaigi.confsched2018.data.db.entity.SponsorPlanEntity
 import org.threeten.bp.Instant
-import org.threeten.bp.LocalDateTime
-import org.threeten.bp.ZoneId
 
 object Converters {
     @JvmStatic
     @TypeConverter
-    fun fromTimestamp(value: Long?): LocalDateTime? {
-        if (value == null) {
-            return null
-        }
-        return LocalDateTime.ofInstant(
-                Instant.ofEpochSecond(value), ZoneId.of("JST", ZoneId.SHORT_IDS))
-    }
+    fun fromTimestamp(value: Long?): Instant? =
+            if (value == null) {
+                null
+            } else {
+                Instant.ofEpochSecond(value)
+            }
 
     @JvmStatic
     @TypeConverter
-    fun dateToTimestamp(date: LocalDateTime?): Long? =
-            date?.atZone(ZoneId.of("JST", ZoneId.SHORT_IDS))?.toEpochSecond()
+    fun dateToTimestamp(date: Instant?): Long? =
+            date?.epochSecond
 
     @JvmStatic
     @TypeConverter

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/SessionDataMapperExt.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/entity/mapper/SessionDataMapperExt.kt
@@ -12,11 +12,11 @@ import io.github.droidkaigi.confsched2018.model.Level
 import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.model.SessionFeedback
-import io.github.droidkaigi.confsched2018.model.SessionSchedule
 import io.github.droidkaigi.confsched2018.model.SessionMessage
+import io.github.droidkaigi.confsched2018.model.SessionSchedule
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
-import io.github.droidkaigi.confsched2018.util.ext.toUnixMills
+import io.github.droidkaigi.confsched2018.util.ext.atJST
 import io.reactivex.Flowable
 import org.threeten.bp.LocalDate
 import org.threeten.bp.Period
@@ -38,9 +38,10 @@ fun SessionWithSpeakers.toSession(
     return Session.SpeechSession(
             id = sessionEntity.id,
             // dayNumber is starts with 1. Example: First day = 1, Second day = 2. So I plus 1 to period days
-            dayNumber = Period.between(firstDay, sessionEntity.stime.toLocalDate()).days + 1,
-            startTime = Date(sessionEntity.stime.toUnixMills()),
-            endTime = Date(sessionEntity.etime.toUnixMills()),
+            dayNumber = Period.between(
+                    firstDay, sessionEntity.stime.atJST().toLocalDate()).days + 1,
+            startTime = Date(sessionEntity.stime.toEpochMilli()),
+            endTime = Date(sessionEntity.etime.toEpochMilli()),
             title = sessionEntity.title,
             desc = sessionEntity.desc,
             room = Room(sessionEntity.room.id, sessionEntity.room.name),

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/fixeddata/SpecialSessions.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/db/fixeddata/SpecialSessions.kt
@@ -1,10 +1,9 @@
 package io.github.droidkaigi.confsched2018.data.db.fixeddata
 
 import io.github.droidkaigi.confsched2018.R
-import io.github.droidkaigi.confsched2018.data.api.response.mapper.LocalDateTimeAdapter
+import io.github.droidkaigi.confsched2018.data.api.response.mapper.InstantAdapter
 import io.github.droidkaigi.confsched2018.model.Room
 import io.github.droidkaigi.confsched2018.model.Session
-import io.github.droidkaigi.confsched2018.util.ext.toUnixMills
 import java.util.Date
 
 class SpecialSessions {
@@ -18,14 +17,12 @@ class SpecialSessions {
                             "100000" + index++,
                             1,
                             Date(
-                                    LocalDateTimeAdapter
-                                            .parseDateString("2018-02-08T10:00:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T10:00:00")
+                                            .toEpochMilli()
                             ),
                             Date(
-                                    LocalDateTimeAdapter
-                                            .parseDateString("2018-02-08T10:20:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T10:20:00")
+                                            .toEpochMilli()
                             ),
                             R.string.session_special_welcome_talk,
                             specialSessionRoom
@@ -34,12 +31,12 @@ class SpecialSessions {
                             "100000" + index++,
                             1,
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-08T11:50:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T11:50:00")
+                                            .toEpochMilli()
                             ),
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-08T12:50:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T12:50:00")
+                                            .toEpochMilli()
                             ),
                             R.string.session_special_lunch,
                             null
@@ -48,12 +45,12 @@ class SpecialSessions {
                             "100000" + index++,
                             1,
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-08T17:40:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T17:40:00")
+                                            .toEpochMilli()
                             ),
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-08T19:40:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-08T19:40:00")
+                                            .toEpochMilli()
                             ),
                             R.string.session_special_party,
                             specialSessionRoom
@@ -63,12 +60,12 @@ class SpecialSessions {
                             "100000" + index,
                             2,
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-09T11:50:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-09T11:50:00")
+                                            .toEpochMilli()
                             ),
                             Date(
-                                    LocalDateTimeAdapter.parseDateString("2018-02-09T12:50:00")
-                                            .toUnixMills()
+                                    InstantAdapter.parseDateString("2018-02-09T12:50:00")
+                                            .toEpochMilli()
                             ),
                             R.string.session_special_lunch,
                             null

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -20,6 +20,7 @@ import io.github.droidkaigi.confsched2018.model.SessionFeedback
 import io.github.droidkaigi.confsched2018.model.SessionSchedule
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
+import io.github.droidkaigi.confsched2018.util.ext.atJST
 import io.github.droidkaigi.confsched2018.util.rx.SchedulerProvider
 import io.reactivex.Completable
 import io.reactivex.Flowable
@@ -58,7 +59,7 @@ class SessionDataRepository @Inject constructor(
                     sessionDatabase.getAllSessionFeedback()
                             .doOnNext { if (DEBUG) Timber.d("feedback") },
                     { sessionEntities, speakerEntities, favList, feedbacks ->
-                        val firstDay = sessionEntities.first().session!!.stime.toLocalDate()
+                        val firstDay = sessionEntities.first().session!!.stime.atJST().toLocalDate()
                         val speakerSessions = sessionEntities
                                 .map { it.toSession(speakerEntities, favList, feedbacks, firstDay) }
                                 .sortedWith(compareBy(

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/NetworkModule.kt
@@ -9,10 +9,10 @@ import io.github.droidkaigi.confsched2018.data.api.FeedFirestoreApi
 import io.github.droidkaigi.confsched2018.data.api.GithubApi
 import io.github.droidkaigi.confsched2018.data.api.SessionFeedbackApi
 import io.github.droidkaigi.confsched2018.data.api.response.mapper.ApplicationJsonAdapterFactory
-import io.github.droidkaigi.confsched2018.data.api.response.mapper.LocalDateTimeAdapter
+import io.github.droidkaigi.confsched2018.data.api.response.mapper.InstantAdapter
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
-import org.threeten.bp.LocalDateTime
+import org.threeten.bp.Instant
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -44,7 +44,7 @@ open class NetworkModule {
                 .baseUrl("https://droidkaigi.jp/2018/")
                 .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
                         .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .add(Instant::class.java, InstantAdapter())
                         .build()))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
                 .build()
@@ -57,7 +57,7 @@ open class NetworkModule {
                 .baseUrl("https://docs.google.com/forms/d/")
                 .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
                         .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .add(Instant::class.java, InstantAdapter())
                         .build()))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
                 .build()
@@ -69,7 +69,7 @@ open class NetworkModule {
                 .baseUrl("https://api.github.com")
                 .addConverterFactory(MoshiConverterFactory.create(Moshi.Builder()
                         .add(ApplicationJsonAdapterFactory.INSTANCE)
-                        .add(LocalDateTime::class.java, LocalDateTimeAdapter())
+                        .add(Instant::class.java, InstantAdapter())
                         .build()))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.createAsync())
                 .client(okHttpClient)

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/InstantEx.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/util/ext/InstantEx.kt
@@ -1,9 +1,9 @@
 package io.github.droidkaigi.confsched2018.util.ext
 
-import org.threeten.bp.LocalDateTime
+import org.threeten.bp.Instant
 import org.threeten.bp.ZoneId
 import org.threeten.bp.ZonedDateTime
 
-fun LocalDateTime.atJST(): ZonedDateTime {
+fun Instant.atJST(): ZonedDateTime {
     return atZone(ZoneId.of("JST", ZoneId.SHORT_IDS))
 }

--- a/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
+++ b/app/src/test/java/io/github/droidkaigi/confsched2018/DummyDataCreator.kt
@@ -13,6 +13,7 @@ import io.github.droidkaigi.confsched2018.model.Session
 import io.github.droidkaigi.confsched2018.model.SessionFeedback
 import io.github.droidkaigi.confsched2018.model.Speaker
 import io.github.droidkaigi.confsched2018.model.Topic
+import io.github.droidkaigi.confsched2018.util.ext.atJST
 import org.threeten.bp.LocalDateTime
 import java.util.Date
 
@@ -152,8 +153,8 @@ fun createDummySessionWithSpeakersEntities(): List<SessionWithSpeakers> {
             SessionWithSpeakers(SessionEntity(DUMMY_SESSION_ID1,
                     DUMMY_SESSION_TITLE1,
                     "Endless battle",
-                    LocalDateTime.of(1, 1, 1, 1, 1),
-                    LocalDateTime.of(1, 1, 1, 1, 1),
+                    LocalDateTime.of(1, 1, 1, 1, 1).atJST().toInstant(),
+                    LocalDateTime.of(1, 1, 1, 1, 1).atJST().toInstant(),
                     "30分",
                     "日本語",
                     LevelEntity(3540, "ニッチ / Niche"),
@@ -164,8 +165,8 @@ fun createDummySessionWithSpeakersEntities(): List<SessionWithSpeakers> {
             SessionWithSpeakers(SessionEntity(DUMMY_SESSION_ID2,
                     DUMMY_SESSION_TITLE2,
                     "Endless battle",
-                    LocalDateTime.of(1, 1, 1, 1, 1),
-                    LocalDateTime.of(1, 1, 1, 1, 1),
+                    LocalDateTime.of(1, 1, 1, 1, 1).atJST().toInstant(),
+                    LocalDateTime.of(1, 1, 1, 1, 1).atJST().toInstant(),
                     "30分",
                     "日本語",
                     LevelEntity(3542, "ニッチ / Niche"),


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)

Currently, Session and SessionEntity class use LocalDateTime.
However, since LocalDateTime does not have TimeZone, it is often misleading about the dependency of TimeZone.

I propose to replace LocalDateTime into Instant.
In the javadoc of Instant, there are the following description.
> This class models a single instantaneous point on the time-line. This might be used to record event time-stamps in the application.

Also, I added javadoc for parseDateString().

By refactoring, it seems to be able to delete redundant transformations such as toUnixMills() and
db.entity.mapper.Converter.

What do you think?

## Links
-

## Screenshot
not changed.
