### PR TITLE
Replaced computation schedulers by io when relevant

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/ContributorDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/ContributorDataRepository.kt
@@ -36,14 +36,14 @@ class ContributorDataRepository @Inject constructor(
                     if (DEBUG) it.forEach { Timber.d("$it") }
                     contributorDatabase.save(it)
                 }
-                .subscribeOn(schedulerProvider.computation())
+                .subscribeOn(schedulerProvider.io())
                 .toCompletable()
     }
 
     override val contributors: Flowable<List<Contributor>> =
             contributorDatabase.getAll()
                     .map { it.toContributors() }
-                    .subscribeOn(schedulerProvider.computation())
+                    .subscribeOn(schedulerProvider.io())
 
     companion object {
         private const val OWNER = "DroidKaigi"

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SessionDataRepository.kt
@@ -68,7 +68,7 @@ class SessionDataRepository @Inject constructor(
 
                         speakerSessions + specialSessions
                     })
-                    .subscribeOn(schedulerProvider.computation())
+                    .subscribeOn(schedulerProvider.io())
                     .doOnNext {
                         if (DEBUG) Timber.d("size:${it.size} current:${System.currentTimeMillis()}")
                     }
@@ -145,7 +145,7 @@ class SessionDataRepository @Inject constructor(
                 .doOnSuccess { response ->
                     sessionDatabase.save(response)
                 }
-                .subscribeOn(schedulerProvider.computation())
+                .subscribeOn(schedulerProvider.io())
                 .toCompletable()
     }
 
@@ -164,7 +164,7 @@ class SessionDataRepository @Inject constructor(
 
     @CheckResult override fun saveSessionFeedback(sessionFeedback: SessionFeedback): Completable =
             Completable.create { sessionDatabase.saveSessionFeedback(sessionFeedback) }
-                    .subscribeOn(schedulerProvider.computation())
+                    .subscribeOn(schedulerProvider.io())
 
     @CheckResult override fun submitSessionFeedback(
             session: Session.SpeechSession,
@@ -183,7 +183,7 @@ class SessionDataRepository @Inject constructor(
             .flatMapCompletable {
                 return@flatMapCompletable saveSessionFeedback(sessionFeedback)
             }
-            .subscribeOn(schedulerProvider.computation())
+            .subscribeOn(schedulerProvider.io())
 
     companion object {
         const val DEBUG = false

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SponsorPlanDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/SponsorPlanDataRepository.kt
@@ -30,6 +30,6 @@ class SponsorPlanDataRepository @Inject constructor(
             }.doOnSuccess {
                 val plansResponse = it
                 sponsorDatabase.save(plansResponse.toSponsorsEntities())
-            }.subscribeOn(schedulerProvider.computation())
+            }.subscribeOn(schedulerProvider.io())
                     .toCompletable()
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
@@ -17,11 +17,11 @@ class StaffDataRepository @Inject constructor(
         private val schedulerProvider: SchedulerProvider
 ) : StaffRepository {
     @CheckResult override fun loadStaff(): Completable = getStaff()
-            .subscribeOn(schedulerProvider.computation())
+            .subscribeOn(schedulerProvider.io())
             .toCompletable()
 
     override val staff: Flowable<List<Staff>>
-        get() = getStaff().toFlowable().subscribeOn(schedulerProvider.computation())
+        get() = getStaff().toFlowable().subscribeOn(schedulerProvider.io())
 
     @CheckResult private fun getStaff(): Single<List<Staff>> {
         return Single.create { emitter ->


### PR DESCRIPTION
## Overview
RxJava's `computation()` is to be used on CPU intensive tasks. Most use cases in the DroidKaigi app are for I/O calls so I use the `io` scheduler instead.
See https://github.com/ReactiveX/RxJava/blob/363f0381c2fcc9df287d771ffd2826c64c998145/src/main/java/io/reactivex/schedulers/Schedulers.java#L90-L136