### PR TITLE
remove needless circle ci cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: sdks-licenses-build-tools-extras-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
-      - restore_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
       - run:
           name: Bundle install
@@ -19,12 +17,6 @@ jobs:
       - run:
           name: Download Dependencies
           command: ./gradlew androidDependencies
-      - save_cache:
-          key: sdks-licenses-build-tools-extras-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
-          paths:
-            - /opt/android/sdk/licenses
-            - /opt/android/sdk/build-tools
-            - /opt/android/sdk/extras
       - save_cache:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
           paths:


### PR DESCRIPTION
## Issue
- close #ISSUE_NUMBER

## Overview (Required)
- apparently caching license agreement files is old custom. It's needless now.

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
