### PR TITLE
use noto font in StickyHeaderItemDecoration

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/itemdecoration/StickyHeaderItemDecoration.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/common/itemdecoration/StickyHeaderItemDecoration.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
-import android.graphics.Typeface
 import android.support.v4.content.ContextCompat
+import android.support.v4.content.res.ResourcesCompat
 import android.support.v7.widget.RecyclerView
 import android.text.TextPaint
 import android.text.TextUtils
@@ -30,7 +30,7 @@ class StickyHeaderItemDecoration constructor(
         val resource = context!!.resources
 
         textPaint.apply {
-            typeface = Typeface.DEFAULT
+            typeface = ResourcesCompat.getFont(context, R.font.notosans_medium)
             isAntiAlias = true
             textSize = resource.getDimension(R.dimen.sticky_label_font_size)
             color = ContextCompat.getColor(context, R.color.primary)


### PR DESCRIPTION
## Issue
- close #638

## Overview (Required)
- apply Noto font to Speaker Sticky label

## Links
- nothing


## Screenshot
Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/5267827/35900251-3fcaf41a-0c14-11e8-9178-066ce0228a9b.png" width="300" /> | <img src="https://user-images.githubusercontent.com/5267827/35900272-6477b258-0c14-11e8-96b5-0dfe33a6b79b.png" width="300" />
