### PR TITLE
Fix TransitionListener was added three times on SharedElementEnterTransition

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/speaker/SpeakerDetailFragment.kt
@@ -16,9 +16,7 @@ import android.view.ViewAnimationUtils
 import android.view.ViewGroup
 import androidx.animation.doOnEnd
 import androidx.os.bundleOf
-import androidx.transition.doOnCancel
-import androidx.transition.doOnEnd
-import androidx.transition.doOnPause
+import androidx.transition.addListener
 import androidx.transition.doOnStart
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.ViewHolder
@@ -149,13 +147,15 @@ class SpeakerDetailFragment : DaggerFragment() {
                     .inflateTransition(R.transition.shared_element_arc)
                     .apply {
                         duration = 400
-                        doOnEnd {
-                            if (!isEnterTransitionCanceled) {
-                                binding.root.post(revealViewRunnable)
-                            }
-                        }
-                        doOnPause { isEnterTransitionCanceled = true }
-                        doOnCancel { isEnterTransitionCanceled = true }
+                        addListener(
+                                onEnd = {
+                                    if (!isEnterTransitionCanceled) {
+                                        binding.root.post(revealViewRunnable)
+                                    }
+                                },
+                                onPause = { isEnterTransitionCanceled = true },
+                                onCancel = { isEnterTransitionCanceled = true }
+                        )
                     }
         } else {
             binding.appBarBackground.toVisible()


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- If using `doOnXXX()` in android-KTX, one listener is added each call
- If we interested animation lifecycle more than one, I think we should use `addListener()` in android-KTX instead of few `doOnXXX()` 

## Screenshot
Before | After
:--: | :--:
<img width="519" alt="before" src="https://user-images.githubusercontent.com/7608725/35901741-850a602c-0c1b-11e8-8844-da4ef1d95f69.png"> | <img width="533" alt="after" src="https://user-images.githubusercontent.com/7608725/35901744-8723dc1c-0c1b-11e8-84bd-95ffbe106dae.png">
