### PR TITLE
Use fragmentmanager isStateSaved function

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/NavigationController.kt
@@ -94,10 +94,15 @@ class NavigationController @Inject constructor(private val activity: AppCompatAc
     }
 
     private fun replaceFragment(fragment: Fragment) {
-        fragmentManager
-                .beginTransaction()
-                .replace(containerId, fragment, (fragment as? Findable)?.tagForFinding)
-                .commitAllowingStateLoss()
+        val transaction = fragmentManager
+            .beginTransaction()
+            .replace(containerId, fragment, (fragment as? Findable)?.tagForFinding)
+
+        if (fragmentManager.isStateSaved) {
+            transaction.commitAllowingStateLoss()
+        } else {
+            transaction.commit()
+        }
     }
 
     fun navigateToContributor() {


### PR DESCRIPTION
We can check the fragmentmanager state before committing the transaction, to use commit() safely instead of blindly using commitAllowingStateLoss(). This enables the commit to not be lost if the activity needs to be restored from its state.

## Issue
- close #ISSUE_NUMBER

## Overview (Required)
-

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
