### PR TITLE
Changed release track to production

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -217,7 +217,7 @@ repositories {
 
 play {
     uploadImages = true
-    track = 'alpha' // 'production' or 'rollout' or 'beta' or 'alpha'
+    track = 'production' // 'production' or 'rollout' or 'beta' or 'alpha'
     untrackOld = true
     // userFraction = 0.1
 }


### PR DESCRIPTION
## Issue
none

## Overview (Required)
Usually we tested the apk via Deploygate, so I guess it's okay to change release track to `production` directly.