### PR TITLE
Use 1st argument as non-null type

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/InstantAdapter.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/api/response/mapper/InstantAdapter.kt
@@ -33,7 +33,7 @@ class InstantAdapter : JsonAdapter<Instant>() {
          * Obtains an instance of Instant from a text string such as "2018-02-08T17:40:00".
          * The string must represent in JST (GMT+9:00).
          */
-        fun parseDateString(dateString: String?): Instant =
+        fun parseDateString(dateString: String): Instant =
                 LocalDateTime.parse(dateString, FORMATTER).atJST().toInstant()
     }
 }


### PR DESCRIPTION
## Overview (Required)
`LocalDateTime.parse` throws an Exception when the first argument is null.
So I guess 1st argument of `IntanstAdapter.parseDateString`should be defined as non-null type to understand what happens more easily when the app crashed.