### PR TITLE
Share RecycledViewPool between view pager content fragments

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -58,12 +58,17 @@ class RoomSessionsFragment :
     @Inject lateinit var sessionAlarm: SessionAlarm
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
-    private val sessionsViewModel: RoomSessionsViewModel by lazy {
+    private val roomSessionsViewModel: RoomSessionsViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory).get(RoomSessionsViewModel::class.java)
     }
 
+    private val sessionsViewModel: SessionsViewModel by lazy {
+        ViewModelProviders.of(parentFragment ?: this, viewModelFactory)
+                .get(SessionsViewModel::class.java)
+    }
+
     private val onFavoriteClickListener = { session: Session.SpeechSession ->
-        sessionsViewModel.onFavoriteClick(session)
+        roomSessionsViewModel.onFavoriteClick(session)
         sessionAlarm.toggleRegister(session)
     }
 
@@ -90,16 +95,16 @@ class RoomSessionsFragment :
         val progressTimeLatch = ProgressTimeLatch {
             binding.progress.visibility = if (it) View.VISIBLE else View.GONE
         }
-        sessionsViewModel.roomName = roomName
-        sessionsViewModel.sessions.observe(this, { result ->
+        roomSessionsViewModel.roomName = roomName
+        roomSessionsViewModel.sessions.observe(this, { result ->
             when (result) {
                 is Result.Success -> {
                     val sessions = result.data
                     sessionsSection.updateSessions(sessions, onFavoriteClickListener,
                             onFeedbackListener, true)
 
-                    sessionsViewModel.onShowSessions()
-                    if (sessionsViewModel.isNeedRestoreScrollState) {
+                    roomSessionsViewModel.onShowSessions()
+                    if (roomSessionsViewModel.isNeedRestoreScrollState) {
                         scrollToPreviousSession()
                     }
                 }
@@ -108,10 +113,10 @@ class RoomSessionsFragment :
                 }
             }
         })
-        sessionsViewModel.isLoading.observe(this, { isLoading ->
+        roomSessionsViewModel.isLoading.observe(this, { isLoading ->
             progressTimeLatch.loading = isLoading ?: false
         })
-        sessionsViewModel.refreshFocusCurrentSession.observe(this, {
+        roomSessionsViewModel.refreshFocusCurrentSession.observe(this, {
             if (it != true) return@observe
             scrollToCurrentSession()
         })
@@ -134,15 +139,15 @@ class RoomSessionsFragment :
     }
 
     override fun requestRestoringScrollState() {
-        if (sessionsViewModel.sessions is Result.Success<*>) {
+        if (roomSessionsViewModel.sessions is Result.Success<*>) {
             scrollToPreviousSession()
         } else {
-            sessionsViewModel.isNeedRestoreScrollState = true
+            roomSessionsViewModel.isNeedRestoreScrollState = true
         }
     }
 
     private fun scrollToPreviousSession() {
-        sessionsViewModel.isNeedRestoreScrollState = false
+        roomSessionsViewModel.isNeedRestoreScrollState = false
         val layoutManager = binding.sessionsRecycler.layoutManager as LinearLayoutManager
         layoutManager.restoreScrollState(PreviousSessionPrefs.scrollState)
         PreviousSessionPrefs.initPreviousSessionPrefs()
@@ -175,6 +180,8 @@ class RoomSessionsFragment :
                     })
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
+            recycledViewPool = sessionsViewModel.viewPool
+            (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -50,6 +50,11 @@ class ScheduleSessionsFragment :
                 .get(ScheduleSessionsViewModel::class.java)
     }
 
+    private val sessionsViewModel: SessionsViewModel by lazy {
+        ViewModelProviders.of(parentFragment ?: this, viewModelFactory)
+                .get(SessionsViewModel::class.java)
+    }
+
     private val onFavoriteClickListener = { session: Session.SpeechSession ->
         scheduleSessionsViewModel.onFavoriteClick(session)
         sessionAlarm.toggleRegister(session)
@@ -112,6 +117,8 @@ class ScheduleSessionsFragment :
             (itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
+            recycledViewPool = sessionsViewModel.viewPool
+            (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
@@ -50,6 +50,7 @@ class SessionsViewModel @Inject constructor(
     val isLoading: LiveData<Boolean> by lazy {
         tab.map { it.inProgress }
     }
+    // Share RecycledViewPool between content fragments of sessions ViewPager.
     val viewPool: RecyclerView.RecycledViewPool by lazy {
         RecyclerView.RecycledViewPool()
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
@@ -6,6 +6,7 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.OnLifecycleEvent
 import android.arch.lifecycle.ViewModel
+import android.support.v7.widget.RecyclerView
 import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.common.mapper.toResult
@@ -48,6 +49,9 @@ class SessionsViewModel @Inject constructor(
     }
     val isLoading: LiveData<Boolean> by lazy {
         tab.map { it.inProgress }
+    }
+    val viewPool: RecyclerView.RecycledViewPool by lazy {
+        RecyclerView.RecycledViewPool()
     }
     private val mutableRefreshState: MutableLiveData<Result<Unit>> = MutableLiveData()
     val refreshResult: LiveData<Result<Unit>> = mutableRefreshState


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Share RecyclerViewPool between content fragments of Sessions ViewPager
  - It will reduce RecyclerView item inflating count.
  - In my environment view inflate count is reduced to 31 from 95
    - Launch app(room mode - all tab) -> select right each room tab in tab order -> switch mode (Day2 14:00) -> select left each tab to all tab in tab order

### Problem

I'm not sure it is appropriate to keep `RecyclerViewPool` on `SessionsViewModel`. I think there are three options.
1. Share through `SessionsViewModel` (This PR is) or other new ViewModel. 
2. Keep pool on SessionFragment and each content Fragment get from it.
3. Keep pool on ViewPager and pass pool from ViewPager to content Fragment

Do you have any advice to give to?   

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
