### PR TITLE
Inject RecycledViewPool by using Dagger2

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/RecycledViewPoolModule.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/RecycledViewPoolModule.kt
@@ -1,0 +1,14 @@
+package io.github.droidkaigi.confsched2018.di
+
+import android.support.v7.widget.RecyclerView
+import dagger.Module
+import dagger.Provides
+
+// Share RecycledViewPool between content fragments of ViewPager.
+@Module class RecycledViewPoolModule {
+
+    private val recycledViewPool = RecyclerView.RecycledViewPool()
+
+    @Provides
+    fun providesRecycledViewPool(): RecyclerView.RecycledViewPool = recycledViewPool
+}

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/activitymodule/MainActivityBuilder.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/activitymodule/MainActivityBuilder.kt
@@ -2,9 +2,10 @@ package io.github.droidkaigi.confsched2018.di.activitymodule
 
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
+import io.github.droidkaigi.confsched2018.di.RecycledViewPoolModule
 import io.github.droidkaigi.confsched2018.presentation.MainActivity
 
 @Module interface MainActivityBuilder {
-    @ContributesAndroidInjector(modules = [MainActivityModule::class])
+    @ContributesAndroidInjector(modules = [MainActivityModule::class, RecycledViewPoolModule::class])
     fun contributeMainActivity(): MainActivity
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/di/activitymodule/MainActivityBuilder.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/di/activitymodule/MainActivityBuilder.kt
@@ -6,6 +6,9 @@ import io.github.droidkaigi.confsched2018.di.RecycledViewPoolModule
 import io.github.droidkaigi.confsched2018.presentation.MainActivity
 
 @Module interface MainActivityBuilder {
-    @ContributesAndroidInjector(modules = [MainActivityModule::class, RecycledViewPoolModule::class])
+    @ContributesAndroidInjector(modules = [
+        MainActivityModule::class,
+        RecycledViewPoolModule::class
+    ])
     fun contributeMainActivity(): MainActivity
 }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/favorite/FavoriteSessionsFragment.kt
@@ -41,6 +41,7 @@ class FavoriteSessionsFragment : DaggerFragment() {
     @Inject lateinit var navigationController: NavigationController
     @Inject lateinit var sessionAlarm: SessionAlarm
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
+    @Inject lateinit var sharedRecycledViewPool: RecyclerView.RecycledViewPool
     private val sessionsViewModel: FavoriteSessionsViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory).get(FavoriteSessionsViewModel::class.java)
     }
@@ -114,6 +115,8 @@ class FavoriteSessionsFragment : DaggerFragment() {
                     })
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
+            recycledViewPool = sharedRecycledViewPool
+            (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }
 

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/AllSessionsFragment.kt
@@ -54,14 +54,10 @@ class AllSessionsFragment :
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var navigationController: NavigationController
     @Inject lateinit var sessionAlarm: SessionAlarm
+    @Inject lateinit var sharedRecycledViewPool: RecyclerView.RecycledViewPool
 
     private val allSessionsViewModel: AllSessionsViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory).get(AllSessionsViewModel::class.java)
-    }
-
-    private val sessionsViewModel: SessionsViewModel by lazy {
-        ViewModelProviders.of(parentFragment ?: this, viewModelFactory)
-                .get(SessionsViewModel::class.java)
     }
 
     private val onFavoriteClickListener = { session: Session.SpeechSession ->
@@ -171,7 +167,7 @@ class AllSessionsFragment :
                     })
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
-            recycledViewPool = sessionsViewModel.viewPool
+            recycledViewPool = sharedRecycledViewPool
             (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/RoomSessionsFragment.kt
@@ -56,15 +56,11 @@ class RoomSessionsFragment :
 
     @Inject lateinit var navigationController: NavigationController
     @Inject lateinit var sessionAlarm: SessionAlarm
+    @Inject lateinit var sharedRecycledViewPool: RecyclerView.RecycledViewPool
 
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     private val roomSessionsViewModel: RoomSessionsViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory).get(RoomSessionsViewModel::class.java)
-    }
-
-    private val sessionsViewModel: SessionsViewModel by lazy {
-        ViewModelProviders.of(parentFragment ?: this, viewModelFactory)
-                .get(SessionsViewModel::class.java)
     }
 
     private val onFavoriteClickListener = { session: Session.SpeechSession ->
@@ -180,7 +176,7 @@ class RoomSessionsFragment :
                     })
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
-            recycledViewPool = sessionsViewModel.viewPool
+            recycledViewPool = sharedRecycledViewPool
             (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/ScheduleSessionsFragment.kt
@@ -4,6 +4,7 @@ import android.arch.lifecycle.ViewModelProvider
 import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.SimpleItemAnimator
 import android.view.LayoutInflater
 import android.view.View
@@ -44,15 +45,11 @@ class ScheduleSessionsFragment :
     @Inject lateinit var viewModelFactory: ViewModelProvider.Factory
     @Inject lateinit var navigationController: NavigationController
     @Inject lateinit var sessionAlarm: SessionAlarm
+    @Inject lateinit var sharedRecycledViewPool: RecyclerView.RecycledViewPool
 
     private val scheduleSessionsViewModel: ScheduleSessionsViewModel by lazy {
         ViewModelProviders.of(this, viewModelFactory)
                 .get(ScheduleSessionsViewModel::class.java)
-    }
-
-    private val sessionsViewModel: SessionsViewModel by lazy {
-        ViewModelProviders.of(parentFragment ?: this, viewModelFactory)
-                .get(SessionsViewModel::class.java)
     }
 
     private val onFavoriteClickListener = { session: Session.SpeechSession ->
@@ -117,7 +114,7 @@ class ScheduleSessionsFragment :
             (itemAnimator as SimpleItemAnimator).supportsChangeAnimations = false
             setLinearDivider(R.drawable.shape_divider_vertical_12dp,
                     layoutManager as LinearLayoutManager)
-            recycledViewPool = sessionsViewModel.viewPool
+            recycledViewPool = sharedRecycledViewPool
             (layoutManager as LinearLayoutManager).recycleChildrenOnDetach = true
         }
     }

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/presentation/sessions/SessionsViewModel.kt
@@ -6,7 +6,6 @@ import android.arch.lifecycle.LiveData
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.OnLifecycleEvent
 import android.arch.lifecycle.ViewModel
-import android.support.v7.widget.RecyclerView
 import io.github.droidkaigi.confsched2018.data.repository.SessionRepository
 import io.github.droidkaigi.confsched2018.presentation.Result
 import io.github.droidkaigi.confsched2018.presentation.common.mapper.toResult
@@ -49,10 +48,6 @@ class SessionsViewModel @Inject constructor(
     }
     val isLoading: LiveData<Boolean> by lazy {
         tab.map { it.inProgress }
-    }
-    // Share RecycledViewPool between content fragments of sessions ViewPager.
-    val viewPool: RecyclerView.RecycledViewPool by lazy {
-        RecyclerView.RecycledViewPool()
     }
     private val mutableRefreshState: MutableLiveData<Result<Unit>> = MutableLiveData()
     val refreshResult: LiveData<Result<Unit>> = mutableRefreshState


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Share RecycledViewPool by using Dagger module
  - ViewModel must not reference a view instance. It may cause memory leaking.

## Links
- https://github.com/DroidKaigi/conference-app-2018/pull/660

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
