### PR TITLE
Replace kotlin stdlib jre7 to jdk7

### DIFF
--- a/versions.gradle
+++ b/versions.gradle
@@ -31,7 +31,7 @@ ext {
 
     depends = [
             kotlin                 : [
-                    stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jre7:$versions.kotlin",
+                    stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlin",
             ],
 
             //==================== Support Library ====================


### PR DESCRIPTION
## Issue
- no issue

## Overview (Required)
- Replace deprecated `kotlin-stdlib-jre7` to `kotlin-stdlib-jdk7`

## Links
- https://discuss.kotlinlang.org/t/kotlin-standard-library-jre-7-8-extensions/3715/4
- https://kotlinlang.org/docs/reference/whatsnew12.html#kotlin-standard-library-artifacts-and-split-packages

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
