### PR TITLE
changed path of gradle defined in chrcleci config to kts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum "app/build.gradle.kts" }}
       - restore_cache:
           key: bundle-{{ checksum "Gemfile.lock" }}
       - run:
@@ -24,7 +24,7 @@ jobs:
           name: Download Dependencies
           command: ./gradlew androidDependencies
       - save_cache:
-          key: jars-{{ checksum "build.gradle" }}-{{ checksum "app/build.gradle" }}
+          key: jars-{{ checksum "build.gradle.kts" }}-{{ checksum "app/build.gradle.kts" }}
           paths:
             - ~/.gradle
       - run:


### PR DESCRIPTION
## Issue
- close #666 

## Overview (Required)
- FIxed .circleci/config.yml.  It changed build.gradle to build.gradle.kts.
- I tested it with my circleci. It made the following settings `APP_BUILD_TYPE=Debug`

## Links
-[circleci build log](https://circleci.com/gh/shikajiro/conference-app-2018/4)

## Screenshot
Nothing
