### PR TITLE
use circleci image which supports ruby

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: punchdrunker/android-27-ruby
+      - image: circleci/android:api-27-alpha
         environment:
           JAVA_OPTS: -Xmx1536m
           GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError"'


### PR DESCRIPTION
## Issue
- close #N.A.

## Overview (Required)
- use official docker image

as I remember that circleci image didn't support ruby, but now they apparently support ruby in android image.

## Links
- https://github.com/CircleCI-Public/circleci-dockerfiles/blob/master/android/images/api-27-alpha/Dockerfile

## Screenshot
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />
