### PR TITLE
fix: StaffDataRepository.staff getter returns new instance each calls

### DIFF
--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
@@ -21,7 +21,7 @@ class StaffDataRepository @Inject constructor(
             .subscribeOn(schedulerProvider.io())
 
     private val sender = BehaviorSubject.createDefault<List<Staff>>(emptyList())
-    override val staff : Flowable<List<Staff>> = sender.toFlowable(BackpressureStrategy.LATEST)
+    override val staff: Flowable<List<Staff>> = sender.toFlowable(BackpressureStrategy.LATEST)
 
     @CheckResult private fun getStaff(): Completable {
         return Completable.create { emitter ->

--- a/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
+++ b/app/src/main/java/io/github/droidkaigi/confsched2018/data/repository/StaffDataRepository.kt
@@ -6,9 +6,10 @@ import io.github.droidkaigi.confsched2018.data.local.LocalJsonParser
 import io.github.droidkaigi.confsched2018.data.local.StaffJsonMapper
 import io.github.droidkaigi.confsched2018.model.Staff
 import io.github.droidkaigi.confsched2018.util.rx.SchedulerProvider
+import io.reactivex.BackpressureStrategy
 import io.reactivex.Completable
 import io.reactivex.Flowable
-import io.reactivex.Single
+import io.reactivex.subjects.BehaviorSubject
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -18,16 +19,16 @@ class StaffDataRepository @Inject constructor(
 ) : StaffRepository {
     @CheckResult override fun loadStaff(): Completable = getStaff()
             .subscribeOn(schedulerProvider.io())
-            .toCompletable()
 
-    override val staff: Flowable<List<Staff>>
-        get() = getStaff().toFlowable().subscribeOn(schedulerProvider.io())
+    private val sender = BehaviorSubject.createDefault<List<Staff>>(emptyList())
+    override val staff : Flowable<List<Staff>> = sender.toFlowable(BackpressureStrategy.LATEST)
 
-    @CheckResult private fun getStaff(): Single<List<Staff>> {
-        return Single.create { emitter ->
+    @CheckResult private fun getStaff(): Completable {
+        return Completable.create { emitter ->
             try {
                 val asset = LocalJsonParser.loadJsonFromAsset(context, "staff.json")
-                emitter.onSuccess(StaffJsonMapper.mapToStaffList(asset))
+                sender.onNext(StaffJsonMapper.mapToStaffList(asset))
+                emitter.onComplete()
             } catch (e: Exception) {
                 Timber.e(e)
                 emitter.onError(e)


### PR DESCRIPTION
## Overview (Required)

ブログを書いていたら、``StaffDataRepository`` に2つの問題があるコードを見つけたので報告しておきます。
アプリの動作には問題となって表れない issue です。

### 1.  ``loadStaff()`` を呼ばなくても ``staff`` の getter で検索処理が実行される

``loadStaff()`` で検索処理が実行され、staff as Flowable を通じて結果が通じると期待しましたが、loadStaff() を呼ばずに staff プロパティを取得するだけで検索処理が実行されてしまいます。
なので、スタッフ画面の起動時に、スタッフ検索処理(``getStaff()``)が2回実行されていました。

### 2.  staff プロパティは get する度に新しい ``Flowable`` のインスタンスを生成してしまう

``staff`` の getter や、 ``loadStaff()`` を呼ぶ度に Flowable インスタンスが再生成されています。
このため、 ``StaffViewModel`` 側の受信処理で

```
val staff: LiveData<Result<List<Staff>>> by lazy {
    repository.staff
            .toResult(schedulerProvider)
            .toLiveData()
}
```

と定義しても、その時の ``repository.staff`` は次回の ``loadStaff()`` 呼び出しで使われなくなってしまうので、結果として、``loadStaff()`` を2度目以降の呼び出しには ``StaffViewModel.staff`` は無反応になります。アプリのスタッフ画面は ``loadStaff()`` が意図して複数回呼び出されるケースがないので、こちらも顕在化しません。