### PR TITLE
Fix decryption failure of publisher key and some bash syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,19 +30,19 @@ jobs:
       - run:
           name: decrypt keystore
           command: |
-              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" =~ ^(master|release)$ ]]; then
                   openssl aes-256-cbc -k $KEYSTORE_DECRYPT_PASSWORD -d -in encrypted-droidkaigi-key -out release.keystore -md sha256
               fi
       - run:
           name: decrypt json
           command: |
-              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" =~ ^(master|release)$ ]]; then
                   openssl aes-256-cbc -k $JSON_DECRYPT_PASSWORD -d -in encrypted-google-services.json -out app/google-services.json -md sha256
               fi
       - run:
           name: Test
           command: |
-              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" =~ ^(master|release)$ ]]; then
                   ./gradlew --stacktrace testRelease
               else
                   ./gradlew --stacktrace test${APP_BUILD_TYPE^}
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Build
           command: |
-              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" =~ ^(master|release)$ ]]; then
                   ./gradlew --offline --stacktrace assembleRelease
               else
                   ./gradlew --offline --stacktrace assemble${APP_BUILD_TYPE^}
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Check
           command: |
-              if [[ "${CIRCLE_BRANCH:-undefined}" != 'master' -a "${CIRCLE_BRANCH:-undefined}" != 'release' ]]; then
+              if [[ ! "${CIRCLE_BRANCH:-undefined}" =~ ^(master|release)$ ]]; then
                   ./gradlew --stacktrace lint${APP_BUILD_TYPE^}
                   ./gradlew --stacktrace ktlint${APP_BUILD_TYPE^}Check
                   bundle exec danger

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,19 +30,19 @@ jobs:
       - run:
           name: decrypt keystore
           command: |
-              if [ $CIRCLE_BRANCH = 'master' -o $CIRCLE_BRANCH = 'release' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
                   openssl aes-256-cbc -k $KEYSTORE_DECRYPT_PASSWORD -d -in encrypted-droidkaigi-key -out release.keystore
               fi
       - run:
           name: decrypt json
           command: |
-              if [ $CIRCLE_BRANCH = 'master' -o $CIRCLE_BRANCH = 'release' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
                   openssl aes-256-cbc -k $JSON_DECRYPT_PASSWORD -d -in encrypted-google-services.json -out app/google-services.json
               fi
       - run:
           name: Test
           command: |
-              if [ $CIRCLE_BRANCH = 'master' -o $CIRCLE_BRANCH = 'release' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
                   ./gradlew --stacktrace testRelease
               else
                   ./gradlew --stacktrace test${APP_BUILD_TYPE^}
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Build
           command: |
-              if [ $CIRCLE_BRANCH = 'master' -o $CIRCLE_BRANCH = 'release' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
                   ./gradlew --offline --stacktrace assembleRelease
               else
                   ./gradlew --offline --stacktrace assemble${APP_BUILD_TYPE^}
@@ -58,7 +58,7 @@ jobs:
       - run:
           name: Check
           command: |
-              if [ ! $CIRCLE_BRANCH = 'master' -a ! $CIRCLE_BRANCH = 'release' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" != 'master' -a "${CIRCLE_BRANCH:-undefined}" != 'release' ]]; then
                   ./gradlew --stacktrace lint${APP_BUILD_TYPE^}
                   ./gradlew --stacktrace ktlint${APP_BUILD_TYPE^}Check
                   bundle exec danger
@@ -66,9 +66,9 @@ jobs:
       - run:
           name: Deploy
           command: |
-              if [ $CIRCLE_BRANCH = 'master' ]; then
+              if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' ]]; then
                   ./gradlew :app:uploadDeployGateRelease
-              elif [[ "${CIRCLE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              elif [[ "${CIRCLE_TAG:-undefined}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                   echo "Deploy to Google Play"
                   openssl aes-256-cbc -k $PUBLISHER_KEYS_JSON_DECRYPT_PASSWORD -d -in encrypted-publisher-keys.json -out app/publisher-keys.json
                   ./gradlew publishApkRelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,13 @@ jobs:
           name: decrypt keystore
           command: |
               if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
-                  openssl aes-256-cbc -k $KEYSTORE_DECRYPT_PASSWORD -d -in encrypted-droidkaigi-key -out release.keystore
+                  openssl aes-256-cbc -k $KEYSTORE_DECRYPT_PASSWORD -d -in encrypted-droidkaigi-key -out release.keystore -md sha256
               fi
       - run:
           name: decrypt json
           command: |
               if [[ "${CIRCLE_BRANCH:-undefined}" == 'master' -o "${CIRCLE_BRANCH:-undefined}" == 'release' ]]; then
-                  openssl aes-256-cbc -k $JSON_DECRYPT_PASSWORD -d -in encrypted-google-services.json -out app/google-services.json
+                  openssl aes-256-cbc -k $JSON_DECRYPT_PASSWORD -d -in encrypted-google-services.json -out app/google-services.json -md sha256
               fi
       - run:
           name: Test
@@ -70,7 +70,7 @@ jobs:
                   ./gradlew :app:uploadDeployGateRelease
               elif [[ "${CIRCLE_TAG:-undefined}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                   echo "Deploy to Google Play"
-                  openssl aes-256-cbc -k $PUBLISHER_KEYS_JSON_DECRYPT_PASSWORD -d -in encrypted-publisher-keys.json -out app/publisher-keys.json
+                  openssl aes-256-cbc -k $PUBLISHER_KEYS_JSON_DECRYPT_PASSWORD -d -in encrypted-publisher-keys.json -out app/publisher-keys.json  -md md5
                   ./gradlew publishApkRelease
               fi
       - store_artifacts:


### PR DESCRIPTION
## Issue
- none but the motivation is in https://circleci.com/gh/DroidKaigi/conference-app-2018/1408

## Overview (Required)

- The default cipher is sha256 since openssl v1.1 but only release publisher key was encrypted by md5.
- Therefore, we need to specify the appropriate cipher. to not only release publisher key just in case.

## Links
- See `openssl aes-256-cbc -k $KEYSTORE_DECRYPT_PASSWORD -d -in encrypted-droidkaigi-key -out release.keystore -md sha256` in https://circleci.com/gh/DroidKaigi/conference-app-2018/1412
- See `openssl aes-256-cbc -k $PUBLISHER_KEYS_JSON_DECRYPT_PASSWORD -d -in encrypted-publisher-keys.json -out app/publisher-keys.json -md md5` in https://circleci.com/gh/DroidKaigi/conference-app-2018/1411